### PR TITLE
Fix field names to match those in landlab Flexure.

### DIFF
--- a/sequence/sediment_flexure.py
+++ b/sequence/sediment_flexure.py
@@ -8,25 +8,25 @@ class SedimentFlexure(Flexure):
     _input_var_names = ("sediment_deposit__thickness", "bedrock_surface__elevation")
 
     _output_var_names = (
-        "bedrock_surface__increment_of_elevation",
+        "bedrock_surface__elevation_increment",
         "bedrock_surface__elevation",
     )
 
     _var_units = {
         "sediment_deposit__thickness": "m",
-        "bedrock_surface__increment_of_elevation": "m",
+        "bedrock_surface__elevation_increment": "m",
         "bedrock_surface__elevation": "m",
     }
 
     _var_mapping = {
         "sediment_deposit__thickness": "node",
-        "bedrock_surface__increment_of_elevation": "node",
+        "bedrock_surface__elevation_increment": "node",
         "bedrock_surface__elevation": "node",
     }
 
     _var_doc = {
         "sediment_deposit__thickness": "Thickness of deposited or eroded sediment",
-        "bedrock_surface__increment_of_elevation": "Amount of subsidence due to sediment loading",
+        "bedrock_surface__elevation_increment": "Amount of subsidence due to sediment loading",
         "bedrock_surface__elevation": "New bedrock elevation following subsidence",
     }
 
@@ -36,8 +36,8 @@ class SedimentFlexure(Flexure):
 
         Flexure.__init__(self, grid, **kwds)
 
-        self.grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
-        self.grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+        self.grid.add_zeros("lithosphere__overlying_pressure_increment", at="node")
+        self.grid.add_zeros("lithosphere_surface__elevation_increment", at="node")
 
     @property
     def rho_sediment(self):
@@ -45,17 +45,17 @@ class SedimentFlexure(Flexure):
 
     def update(self):
         dz = self.grid.at_node["sediment_deposit__thickness"]
-        self.grid.at_node["lithosphere__increment_of_overlying_pressure"][:] = (
+        self.grid.at_node["lithosphere__overlying_pressure_increment"][:] = (
             dz * self.rho_sediment * self.gravity
         )
 
         Flexure.update(self)
 
-        dz = self.grid.at_node["lithosphere_surface__increment_of_elevation"]
-        self.grid.at_node["bedrock_surface__increment_of_elevation"][:] = dz
+        dz = self.grid.at_node["lithosphere_surface__elevation_increment"]
+        self.grid.at_node["bedrock_surface__elevation_increment"][:] = dz
 
-        self.grid.at_node["bedrock_surface__elevation"] -= dz
-        self.grid.at_node["topographic__elevation"] -= dz
+        self.grid.at_node["bedrock_surface__elevation"] += dz
+        self.grid.at_node["topographic__elevation"] += dz
 
     def run_one_step(self, dt=None):
         self.update()


### PR DESCRIPTION
This pull request fixes the field names used by the `SedimentFlexure` component - although the names were probably better here. In any case, they are now,
*  `lithosphere__overlying_pressure_increment`
* `bedrock_surface__elevation_increment`