### PR TITLE
Add time keyword for write_raster_netcdf.

### DIFF
--- a/sequence/raster_model.py
+++ b/sequence/raster_model.py
@@ -31,17 +31,18 @@ class RasterModel(object):
     def run_one_step(self, dt=None, output=None):
         """Run each component for one time step."""
         dt = dt or self.clock.step
-        self.clock.advance(step=dt)
+        self.clock.dt = dt
+        self.clock.advance()
 
         self.advance_components(dt)
 
         if output:
-            write_raster_netcdf(output, self.grid, append=True)
+            write_raster_netcdf(output, self.grid, append=True, time=self.clock.time)
 
     def run(self, output=None):
         """Run the model until complete."""
         if output:
-            write_raster_netcdf(output, self.grid, append=False)
+            write_raster_netcdf(output, self.grid, append=False, time=self.clock.time)
 
         try:
             while 1:


### PR DESCRIPTION
This pull request uses the `time` keyword when writing files with `write_raster_netcdf` so that fields are appended to the file as the model advances in time. At the moment, this requires a development version of landlab that fixes a bug where fields were being overwritten instead of appended ([#778](https://github.com/landlab/landlab/pull/778)).