### PR TITLE
Remove nose utilities, use pytest

### DIFF
--- a/sequence/tests/test_shoreline.py
+++ b/sequence/tests/test_shoreline.py
@@ -1,6 +1,7 @@
 """Test the shoreline.find_shoreline function."""
 import numpy as np
-from nose.tools import assert_almost_equal, raises
+import pytest
+from pytest import approx
 
 from sequence.shoreline import find_shoreline
 
@@ -14,16 +15,16 @@ hi_value = 100.0
 lo_value = -100.0
 
 
-@raises(TypeError)
 def test_find_shoreline_fails_with_no_args():
     """Test find_shoreline fails with no arguments"""
-    find_shoreline()
+    with pytest.raises(TypeError):
+        find_shoreline()
 
 
-@raises(TypeError)
 def test_find_shoreline_fails_with_one_arg():
     """Test find_shoreline fails with one argument"""
-    find_shoreline(x)
+    with pytest.raises(TypeError):
+        find_shoreline(x)
 
 
 def test_find_shoreline_with_default_keywords():
@@ -38,74 +39,74 @@ def test_find_shoreline_with_list_args():
     find_shoreline(x_list, z_list)
 
 
-@raises(ValueError)
 def test_find_shoreline_fails_with_different_len_args():
     """Test find_shoreline fails with arguments of different length"""
     new_x = np.arange(float(len(x) + 1))
-    find_shoreline(new_x, z)
+    with pytest.raises(ValueError):
+        find_shoreline(new_x, z)
 
 
-@raises(NotImplementedError)
 def test_find_shoreline_fails_with_unknown_kind():
     """Test find_shoreline fails with unknown interpolation"""
-    find_shoreline(x, z, kind="foobarbaz")
+    with pytest.raises(NotImplementedError):
+        find_shoreline(x, z, kind="foobarbaz")
 
 
 def test_find_shoreline_return_value():
     """Test find_shoreline return value"""
     r = find_shoreline(x, z)
-    assert_almost_equal(r, expected_value)
+    assert r == approx(expected_value)
 
 
 def test_find_shoreline_return_value_with_sea_level():
     """Test find_shoreline return value with sea level"""
     r = find_shoreline(x, z, sea_level=sea_level)
-    assert_almost_equal(r, expected_value_with_sea_level)
+    assert r == approx(expected_value_with_sea_level)
 
 
 def test_find_shoreline_return_value_with_hi_sea_level():
     """Test find_shoreline return value with high sea level"""
     r = find_shoreline(x, z, sea_level=hi_value)
-    assert_almost_equal(r, x[0])
+    assert r == approx(x[0])
 
 
 def test_find_shoreline_return_value_with_lo_sea_level():
     """Test find_shoreline return value with low sea level"""
     r = find_shoreline(x, z, sea_level=lo_value)
-    assert_almost_equal(r, x[-1])
+    assert r == approx(x[-1])
 
 
 def test_find_shoreline_with_kind_linear():
     """Test find_shoreline with linear interpolation"""
     r = find_shoreline(x, z, kind="linear")
-    assert_almost_equal(r, expected_value)
+    assert r == approx(expected_value)
 
 
 def test_find_shoreline_with_kind_nearest():
     """Test find_shoreline with nearest interpolation"""
     r = find_shoreline(x, z, kind="nearest")
-    assert_almost_equal(r, expected_value)
+    assert r == approx(expected_value)
 
 
 def test_find_shoreline_with_kind_zero():
     """Test find_shoreline with zero interpolation"""
     r = find_shoreline(x, z, kind="zero")
-    assert_almost_equal(r, expected_value)
+    assert r == approx(expected_value)
 
 
 def test_find_shoreline_with_kind_slinear():
     """Test find_shoreline with slinear interpolation"""
     r = find_shoreline(x, z, kind="slinear")
-    assert_almost_equal(r, expected_value)
+    assert r == approx(expected_value)
 
 
 def test_find_shoreline_with_kind_quadratic():
     """Test find_shoreline with quadratic interpolation"""
     r = find_shoreline(x, z, kind="quadratic")
-    assert_almost_equal(r, expected_value)
+    assert r == approx(expected_value)
 
 
 def test_find_shoreline_with_kind_cubic():
     """Test find_shoreline with cubic interpolation"""
     r = find_shoreline(x, z, kind="cubic")
-    assert_almost_equal(r, expected_value)
+    assert r == approx(expected_value)


### PR DESCRIPTION
This pull request removes nose utilities from our unit tests. Instead, use `pytest.raises`, `pytest.approx` for tests.