### PR TITLE
Mcflugen/change bathymetry reader to read seafloor

### DIFF
--- a/sequence/bathymetry.py
+++ b/sequence/bathymetry.py
@@ -10,13 +10,13 @@ class BathymetryReader(Component):
 
     _input_var_names = ()
 
-    _output_var_names = ("bedrock_surface__elevation",)
+    _output_var_names = ("topographic__elevation",)
 
-    _var_units = {"bedrock_surface__elevation": "m"}
+    _var_units = {"topographic__elevation": "m"}
 
-    _var_mapping = {"bedrock_surface__elevation": "node"}
+    _var_mapping = {"topographic__elevation": "node"}
 
-    _var_doc = {"bedrock_surface__elevation": "Surface elevation"}
+    _var_doc = {"topographic__elevation": "Surface elevation"}
 
     def __init__(self, grid, filepath=None, kind="linear", **kwds):
         """Generate a bathymetric profile from a file.
@@ -44,8 +44,8 @@ class BathymetryReader(Component):
             bounds_error=True,
         )
 
-        if "bedrock_surface__elevation" not in self.grid.at_node:
-            self.grid.add_zeros("bedrock_surface__elevation", at="node")
+        if "topographic__elevation" not in self.grid.at_node:
+            self.grid.add_zeros("topographic__elevation", at="node")
 
     @property
     def x(self):
@@ -53,10 +53,10 @@ class BathymetryReader(Component):
 
     @property
     def z(self):
-        return self.grid.at_node["bedrock_surface__elevation"][
+        return self.grid.at_node["topographic__elevation"][
             self.grid.nodes_at_bottom_edge
         ]
 
     def run_one_step(self, dt=None):
-        z = self.grid.at_node["bedrock_surface__elevation"].reshape(self.grid.shape)
+        z = self.grid.at_node["topographic__elevation"].reshape(self.grid.shape)
         z[:] = self._bathymetry(self.grid.x_of_node[self.grid.nodes_at_bottom_edge])

--- a/sequence/bathymetry.py
+++ b/sequence/bathymetry.py
@@ -34,7 +34,7 @@ class BathymetryReader(Component):
         """
         super(BathymetryReader, self).__init__(grid, **kwds)
 
-        data = np.loadtxt(filepath, delimiter=",")
+        data = np.loadtxt(filepath, delimiter=",", comments="#")
         self._bathymetry = interp1d(
             data[:, 0],
             data[:, 1],

--- a/sequence/sequence_model.py
+++ b/sequence/sequence_model.py
@@ -57,7 +57,9 @@ class SequenceModel(RasterModel):
 
         BathymetryReader(self.grid, **bathymetry).run_one_step()
 
-        z0 = self.grid.at_node["bedrock_surface__elevation"]
+        z = self.grid.at_node["topographic__elevation"]
+        z0 = self.grid.add_empty("bedrock_surface__elevation", at="node")
+        z0[:] = z - 10.
 
         self.grid.layers.add(
             10.,
@@ -66,9 +68,6 @@ class SequenceModel(RasterModel):
             t0=10.,
             percent_sand=0.5,
         )
-
-        z = self.grid.add_empty("topographic__elevation", at="node")
-        z[:] = z0 + 10.
 
         self._sea_level = SinusoidalSeaLevel(
             self.grid, start=clock["start"], **sea_level

--- a/sequence/subsidence.py
+++ b/sequence/subsidence.py
@@ -48,7 +48,7 @@ class SubsidenceTimeSeries(Component):
         """
         super(SubsidenceTimeSeries, self).__init__(grid, **kwds)
 
-        data = np.loadtxt(filepath, delimiter=",")
+        data = np.loadtxt(filepath, delimiter=",", comments="#")
         subsidence = interp1d(
             data[:, 0],
             data[:, 1],

--- a/sequence/tests/test_bathymetry.py
+++ b/sequence/tests/test_bathymetry.py
@@ -10,7 +10,7 @@ from sequence.bathymetry import BathymetryReader
 
 @pytest.fixture(scope="session")
 def bathy_file(tmpdir_factory):
-    lines = ["0., 10.", "2., 0.", "4., -5."]
+    lines = ["# x (m), z (m)", "0., 10.", "2., 0.", "4., -5."]
     file_ = tmpdir_factory.mktemp("data").join("bathy.csv")
     file_.write(os.linesep.join(lines))
     return str(file_)
@@ -36,9 +36,9 @@ def test_reading_from_file(bathy_file):
 def test_output_is_topography(bathy_file):
     grid = RasterModelGrid((3, 5), spacing=.2)
 
-    assert "topographic__elevation" not in self.grid.at_node
+    assert "topographic__elevation" not in grid.at_node
     BathymetryReader(grid, filepath=bathy_file).run_one_step()
-    assert "topographic__elevation" in self.grid.at_node
+    assert "topographic__elevation" in grid.at_node
 
 
 def test_field_already_exists(bathy_file):

--- a/sequence/tests/test_bathymetry.py
+++ b/sequence/tests/test_bathymetry.py
@@ -1,0 +1,116 @@
+import os
+
+import numpy as np
+import pytest
+from pytest import approx, raises
+
+from landlab import RasterModelGrid
+from sequence.bathymetry import BathymetryReader
+
+
+@pytest.fixture(scope="session")
+def bathy_file(tmpdir_factory):
+    lines = ["0., 10.", "2., 0.", "4., -5."]
+    file_ = tmpdir_factory.mktemp("data").join("bathy.csv")
+    file_.write(os.linesep.join(lines))
+    return str(file_)
+
+
+def test_reading_from_file(bathy_file):
+    expected = np.array(
+        [
+            [10., 9., 8., 7., 6.],
+            [10., 9., 8., 7., 6.],
+            [10., 9., 8., 7., 6.],
+        ]
+    )
+
+    grid = RasterModelGrid((3, 5), spacing=.2)
+    bathy = BathymetryReader(grid, filepath=bathy_file)
+    bathy.run_one_step()
+
+    actual = bathy.grid.at_node["topographic__elevation"].reshape(grid.shape)
+    assert actual == approx(expected)
+
+
+def test_output_is_topography(bathy_file):
+    grid = RasterModelGrid((3, 5), spacing=.2)
+
+    assert "topographic__elevation" not in self.grid.at_node
+    BathymetryReader(grid, filepath=bathy_file).run_one_step()
+    assert "topographic__elevation" in self.grid.at_node
+
+
+def test_field_already_exists(bathy_file):
+    expected = np.array(
+        [
+            [10., 9., 8., 7., 6.],
+            [10., 9., 8., 7., 6.],
+            [10., 9., 8., 7., 6.],
+        ]
+    )
+
+    grid = RasterModelGrid((3, 5), spacing=.2)
+    grid.add_zeros("topographic__elevation", at="node")
+    bathy = BathymetryReader(grid, filepath=bathy_file)
+    bathy.run_one_step()
+
+    actual = bathy.grid.at_node["topographic__elevation"].reshape(grid.shape)
+    assert actual == approx(expected)
+
+
+def test_no_extrapolate(bathy_file):
+    grid = RasterModelGrid((3, 5), spacing=2.)
+    bathy = BathymetryReader(grid, filepath=bathy_file)
+    with raises(ValueError):
+        bathy.run_one_step()
+
+    grid = RasterModelGrid((3, 5), spacing=-1.)
+    bathy = BathymetryReader(grid, filepath=bathy_file)
+    with raises(ValueError):
+        bathy.run_one_step()
+
+
+def test_kind_is_nearest(bathy_file):
+    expected = np.full((3, 5), 10.)
+
+    grid = RasterModelGrid((3, 5), spacing=.2)
+    bathy = BathymetryReader(grid, filepath=bathy_file, kind="nearest")
+    bathy.run_one_step()
+
+    actual = bathy.grid.at_node["topographic__elevation"].reshape(grid.shape)
+    assert actual == approx(expected)
+
+
+def test_kind_is_previous(bathy_file):
+    expected = np.array(
+        [
+            [10., 10., 10., 10., 0.],
+            [10., 10., 10., 10., 0.],
+            [10., 10., 10., 10., 0.],
+        ]
+    )
+
+    grid = RasterModelGrid((3, 5), spacing=.5)
+    bathy = BathymetryReader(grid, filepath=bathy_file, kind="previous")
+    bathy.run_one_step()
+
+    actual = bathy.grid.at_node["topographic__elevation"].reshape(grid.shape)
+    assert actual == approx(expected)
+
+
+def test_kind_is_next(bathy_file):
+    expected = np.array(
+        [
+            [10., 0., 0., 0., 0.],
+            [10., 0., 0., 0., 0.],
+            [10., 0., 0., 0., 0.],
+        ]
+    )
+
+    grid = RasterModelGrid((3, 5), spacing=.5)
+    bathy = BathymetryReader(grid, filepath=bathy_file, kind="next")
+    bathy.run_one_step()
+
+    actual = bathy.grid.at_node["topographic__elevation"].reshape(grid.shape)
+    assert actual == approx(expected)


### PR DESCRIPTION
This pull request changes the `BathymetryReader` to read data into the `"topographic__elevation"` field rather than into `"bedrock_surface__elevation"`. I've also added some unit tests for `BathymetryReader`.