### PR TITLE
Add time varying params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ install:
 script:
 - pytest --cov=sequence --cov-report= --cov-report=xml -vvv
 - make lint install
+- mkdir example
 - sequence setup example
 - sequence run example
 - sequence run data/marmara/

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ install:
 script:
 - pytest --cov=sequence --cov-report= --cov-report=xml -vvv
 - make lint install
-- sequence run data/marmara/marmara.yaml
+- sequence setup example
+- sequence run example
+- sequence run data/marmara/
 after_success:
 - coveralls --verbose

--- a/README.rst
+++ b/README.rst
@@ -54,14 +54,14 @@ To then install *Sequence* into this environment::
 Input Files
 -----------
 
-Parameter File
-++++++++++++++
+Sequence Parameter File
++++++++++++++++++++++++
 
 The main *Sequence* input file is a yaml-formatted text file that lists
 parameter values for the various components. Running the following will
 print a sample *Sequence* parameter file::
 
-  $ sequence show params
+  $ sequence show sequence
 
 Bathymetry File
 +++++++++++++++
@@ -121,8 +121,8 @@ To run a simulation using the sample input files described above, you first
 need to create a set of sample files::
 
   $ sequence setup example
-  example/sequence.yaml
+  example
 
 You can now run the simulation::
 
-  $ sequence run example/sequence.yaml
+  $ sequence run example

--- a/data/marmara/sequence.yaml
+++ b/data/marmara/sequence.yaml
@@ -57,3 +57,9 @@ sediments:
 #   river_concentration: .1
 #   sediment_removal_rate: 2.
 #   sediment_bulk_density: 1600.
+compaction:
+  c: 5.0e-08
+  porosity_max: 0.5
+  porosity_min: 0.01
+  rho_grain: 2650.0
+  rho_void: 1000.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
+    "scipy.interpolate",
     # "IPython.sphinxext.ipython_console_highlighting",
     # "sphinxcontrib_github_alt",
 

--- a/sequence/bathymetry.py
+++ b/sequence/bathymetry.py
@@ -1,7 +1,8 @@
 #! /usr/bin/env python
 import numpy as np
-from landlab import Component
 from scipy.interpolate import interp1d
+
+from landlab import Component
 
 
 class BathymetryReader(Component):

--- a/sequence/cli.py
+++ b/sequence/cli.py
@@ -27,7 +27,7 @@ def _contents_of_input_file(infile, set):
         return contents
 
     contents = {
-        "config": yaml.dump(params, default_flow_style=False),
+        "sequence": yaml.dump(params, default_flow_style=False),
         "bathymetry": as_csv(
             [[0.0, 20.0], [100000.0, -80.0]], header="X [m], Elevation [m]"
         ),
@@ -40,7 +40,7 @@ def _contents_of_input_file(infile, set):
         ),
     }
     for section, section_params in params.items():
-        contents[f"config.{section}"] = yaml.dump(
+        contents[f"sequence.{section}"] = yaml.dump(
             section_params, default_flow_style=False
         )
 
@@ -85,7 +85,7 @@ def sequence():
 
       Run a simulation using the examples input files,
 
-        $ sequence run sequence-example/config.yaml
+        $ sequence run sequence-example
     """
     pass
 
@@ -142,8 +142,8 @@ def run(run_dir, with_citations, verbose, dry_run):
     "infile",
     type=click.Choice(
         sorted(
-            ["bathymetry", "config", "config.output", "sealevel", "subsidence"]
-            + [f"config.{name}" for name in SequenceModel.DEFAULT_PARAMS]
+            ["bathymetry", "sequence", "sequence.output", "sealevel", "subsidence"]
+            + [f"sequence.{name}" for name in SequenceModel.DEFAULT_PARAMS]
         )
     ),
 )
@@ -165,7 +165,7 @@ def setup(destination, set):
 
     files = [
         pathlib.Path(fname)
-        for fname in ["bathymetry.csv", "config.yaml", "sealevel.csv", "subsidence.csv"]
+        for fname in ["bathymetry.csv", "sequence.yaml", "sealevel.csv", "subsidence.csv"]
     ]
 
     existing_files = [folder / name for name in files if (folder / name).exists()]
@@ -178,6 +178,6 @@ def setup(destination, set):
         for fname in files:
             with open(folder / fname, "w") as fp:
                 print(_contents_of_input_file(fname.stem, set), file=fp)
-        print(str(folder / "config.yaml"))
+        print(str(folder))
 
     sys.exit(len(existing_files))

--- a/sequence/fluvial.py
+++ b/sequence/fluvial.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 import numpy as np
+
 from landlab import Component
 
 from .shoreline import find_shoreline

--- a/sequence/input_reader.py
+++ b/sequence/input_reader.py
@@ -1,0 +1,192 @@
+import pathlib
+
+import numpy as np
+import yaml
+
+
+class TimeVaryingConfig:
+    """A configuration dictionary that is able to change with time.
+
+    Parameters
+    ----------
+    times : iterable of int
+        Time keys for each dictionary.
+    dicts : iterable of dict
+        Dictionary to use at each time.
+
+    Examples
+    --------
+    >>> from sequence.input_reader import TimeVaryingConfig
+    >>> params = TimeVaryingConfig([0, 1], [dict(foo=0, bar=1), dict(foo=1)])
+    >>> sorted(params.items())
+    [(('bar',), 1), (('foo',), 0)]
+    >>> params.update(1)
+    {'foo': 1}
+    >>> sorted(params.items())
+    [(('bar',), 1), (('foo',), 1)]
+    """
+
+    def __init__(self, times, dicts):
+        self._times = tuple(times)
+        self._dicts = [_flatten_dict(d) for d in dicts]
+        self._time = 0
+
+        for d in self._dicts:
+            for key, value in d.items():
+                if isinstance(value, list):
+                    d[key] = tuple(value)
+
+        self._current = self._dicts[0]
+
+    def items(self):
+        return self._current.items()
+
+    def as_dict(self):
+        return _expand_dict(self._current)
+
+    def __call__(self, time):
+        d = {}
+        for next_dict in self._dicts[: self._bisect_times(time)]:
+            d.update(next_dict)
+        return d
+
+    def _bisect_times(self, time):
+        return np.searchsorted(self._times, time, side="right")
+
+    def diff(self, start, stop):
+        start, stop = self(start), self(stop)
+        return {k: stop[k] for k, _ in set(stop.items()) - set(start.items())}
+
+    def update(self, inc):
+        next_time = self._time + inc
+        prev, next_ = self._bisect_times([self._time, next_time])
+        if next_ > prev:
+            self._current = self(next_time)
+            diff = _expand_dict(self.diff(self._time, next_time))
+        else:
+            diff = {}
+
+        self._time = next_time
+        return diff
+
+    def dump(self):
+        docs = [_expand_dict(self._dicts[0])]
+        for prev, next_ in zip(self._times[:-1], self._times[1:]):
+            docs.append(_expand_dict(self.diff(prev, next_)))
+        for time, doc in zip(self._times, docs):
+            doc["_time"] = time
+        return yaml.dump_all(docs, default_flow_style=False)
+
+    @classmethod
+    def from_files(cls, names, times=None):
+        if times is None:
+            times = list(range(len(names)))
+        dicts = []
+        for name in [pathlib.Path(n) for n in names]:
+            with open(name, "r") as fp:
+                dicts.append(yaml.safe_load(fp))
+        return cls(times, dicts)
+
+    @classmethod
+    def from_file(cls, name):
+        with open(name, "r") as fp:
+            dicts = yaml.safe_load_all(fp)
+            times = [d.pop("_time", index) for index, d in enumerate(dicts)]
+        return cls(times, dicts)
+
+
+def _flatten_dict(d, sep=None):
+    """Flatten a dictionary so that each value has it's own key.
+
+    Parameters
+    ----------
+    d : dict
+        The dictionary to flatten.
+    sep : str, optional
+        Separator to use when creating flattened keys.
+
+    Returns
+    ------
+    dict
+        A flattened version of the dictionary.
+
+    Examples
+    --------
+    >>> from sequence.input_reader import _flatten_dict
+    >>> sorted(_flatten_dict({"foo": 0, "bar": 1}).items())
+    [(('bar',), 1), (('foo',), 0)]
+    >>> sorted(_flatten_dict({"foo": {"baz": 0, "foobar": "baz"}, "bar": 1}).items())
+    [(('bar',), 1), (('foo', 'baz'), 0), (('foo', 'foobar'), 'baz')]
+    >>> sorted(_flatten_dict(
+    ...     {"foo": {"baz": 0, "foobar": "baz"}, "bar": 1}, sep=".").items()
+    ... )
+    [('bar', 1), ('foo.baz', 0), ('foo.foobar', 'baz')]
+    """
+    if sep is None:
+        return {keys: value for keys, value in _walk_dict(d)}
+    else:
+        return {sep.join(keys): value for keys, value in _walk_dict(d)}
+
+
+def _add_flattened_item(keys, value, base=None):
+    expanded = {} if base is None else base
+    parent, name = keys[:-1], keys[-1]
+
+    level = expanded
+    for k in parent:
+        if k not in level:
+            level[k] = dict()
+        level = level[k]
+    if isinstance(value, tuple):
+        value = list(value)
+    level[name] = value
+
+    return base
+
+
+def _expand_dict(flat_dict):
+    expanded = dict()
+    for key, value in flat_dict.items():
+        _add_flattened_item(key, value, base=expanded)
+    return expanded
+
+
+def _walk_dict(indict, prev=None):
+    """Walk the elements of a dictionary.
+
+    Parameters
+    ----------
+    indict : dict
+        The dictionary to walk.
+    prev : dict, optional
+        The parent dictionary, if any, that is being walked.
+
+    Yields
+    ------
+    tuple of (*keys*, value)
+        The first element of the tuple is itself a tuple of the keys that have
+        been walked to get to this point, the second the value.
+
+    Examples
+    --------
+    >>> from sequence.input_reader import _walk_dict
+    >>> sorted(_walk_dict({"foo": 0, "bar": 1}))
+    [(('bar',), 1), (('foo',), 0)]
+    >>> sorted(_walk_dict({"foo": {"baz": 0}, "bar": 1}))
+    [(('bar',), 1), (('foo', 'baz'), 0)]
+    >>> sorted(_walk_dict({"foo": {"bar": {"baz": 0, "foo": "bar"}}, "bar": 1}))
+    [(('bar',), 1), (('foo', 'bar', 'baz'), 0), (('foo', 'bar', 'foo'), 'bar')]
+    """
+    prev = tuple(prev) if prev else ()
+
+    if isinstance(indict, dict):
+        for key, value in indict.items():
+            if isinstance(value, dict):
+                for d in _walk_dict(value, prev + (key,)):
+                    yield d
+            elif isinstance(value, list) or isinstance(value, tuple):
+                yield prev + (key,), value
+            else:
+                yield prev + (key,), value
+    else:
+        yield indict

--- a/sequence/raster_model.py
+++ b/sequence/raster_model.py
@@ -2,6 +2,7 @@
 import argparse
 
 import yaml
+
 from landlab import RasterModelGrid
 from landlab.bmi.bmi_bridge import TimeStepper
 from landlab.core import load_params

--- a/sequence/sea_level.py
+++ b/sequence/sea_level.py
@@ -1,6 +1,7 @@
 import numpy as np
-from landlab import Component
 from scipy.interpolate import interp1d
+
+from landlab import Component
 
 
 class SeaLevelTimeSeries(Component):
@@ -35,8 +36,17 @@ class SeaLevelTimeSeries(Component):
         """
         super(SeaLevelTimeSeries, self).__init__(grid, **kwds)
 
-        data = np.loadtxt(filepath, delimiter=",")
-        self._sea_level = interp1d(
+        self._filepath = filepath
+        self._kind = kind
+
+        self._sea_level = SeaLevelTimeSeries._sea_level_interpolator(
+            np.loadtxt(self._filepath, delimiter=","), kind=self._kind
+        )
+        self._time = start
+
+    @staticmethod
+    def _sea_level_interpolator(data, kind="linear"):
+        return interp1d(
             data[:, 0],
             data[:, 1],
             kind=kind,
@@ -45,7 +55,16 @@ class SeaLevelTimeSeries(Component):
             bounds_error=True,
         )
 
-        self._time = start
+    @property
+    def filepath(self):
+        return self._filepath
+
+    @filepath.setter
+    def filepath(self, new_path):
+        self._filepath = new_path
+        self._sea_level = SeaLevelTimeSeries._sea_level_interpolator(
+            np.loadtxt(self._filepath, delimiter=","), kind=self._kind
+        )
 
     @property
     def time(self):

--- a/sequence/sediment_flexure.py
+++ b/sequence/sediment_flexure.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from landlab.components.flexure import Flexure1D
 
 

--- a/sequence/shoreline.py
+++ b/sequence/shoreline.py
@@ -2,6 +2,7 @@
 import bisect
 
 import numpy as np
+
 from landlab import Component
 
 from .errors import ShelfEdgeError, ShorelineError

--- a/sequence/submarine.py
+++ b/sequence/submarine.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 import numpy as np
+
 from landlab.components import LinearDiffuser
 
 from .shoreline import find_shoreline

--- a/sequence/subsidence.py
+++ b/sequence/subsidence.py
@@ -1,7 +1,8 @@
 #! /usr/bin/env python
 import numpy as np
-from landlab import Component
 from scipy.interpolate import interp1d
+
+from landlab import Component
 
 
 class SubsidenceTimeSeries(Component):

--- a/tests/test_bathymetry.py
+++ b/tests/test_bathymetry.py
@@ -2,9 +2,9 @@ import os
 
 import numpy as np
 import pytest
-from landlab import RasterModelGrid
 from pytest import approx, raises
 
+from landlab import RasterModelGrid
 from sequence.bathymetry import BathymetryReader
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+import pytest
+from click.testing import CliRunner
+
+from sequence.cli import sequence
+
+
+def test_command_line_interface():
+    """Test the CLI."""
+    runner = CliRunner()
+    result = runner.invoke(sequence, ["--help"])
+    assert result.exit_code == 0
+
+    result = runner.invoke(sequence, ["--version"])
+    assert result.exit_code == 0
+    assert "version" in result.output
+
+
+@pytest.mark.parametrize("subcommand", ("run", "show", "setup"))
+def test_subcommand_help(subcommand):
+    runner = CliRunner()
+    result = runner.invoke(sequence, [subcommand, "--help"])
+    assert result.exit_code == 0

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -1,8 +1,8 @@
 import numpy as np
 import xarray as xr
-from landlab import RasterModelGrid
 from pytest import approx
 
+from landlab import RasterModelGrid
 from sequence.netcdf import to_netcdf
 
 

--- a/tests/test_output_writer.py
+++ b/tests/test_output_writer.py
@@ -1,8 +1,8 @@
 import numpy as np
 import xarray as xr
-from landlab import RasterModelGrid
 from pytest import approx, raises
 
+from landlab import RasterModelGrid
 from sequence import OutputWriter
 
 

--- a/tests/test_sequence_model.py
+++ b/tests/test_sequence_model.py
@@ -2,7 +2,6 @@ import os
 import shutil
 
 from landlab.core import load_params
-
 from sequence.sequence_model import SequenceModel
 
 

--- a/tests/test_sequence_model/marmara.yaml
+++ b/tests/test_sequence_model/marmara.yaml
@@ -57,3 +57,9 @@ sediments:
 #   river_concentration: .1
 #   sediment_removal_rate: 2.
 #   sediment_bulk_density: 1600.
+compaction:
+  c: 5.0e-08
+  porosity_max: 0.5
+  porosity_min: 0.01
+  rho_grain: 2650.0
+  rho_void: 1000.0


### PR DESCRIPTION
This pull request adds input variables that can vary with time over the model simulation. A series of configuration files, with time stamps, are read, and as each time stamp is reached in the model simulation, the parameters are updated.

Configuration file names are of the form `sequence<time>.yaml` where `<time>` is an optional integer that gives the time step for that set of parameters.

As an example, if *sequence.yaml* contains the following,
```yaml
sea_level:
  filepath: marmara_sea_level.csv
```
and *sequence-100.yaml* contains the following,
```yaml
sea_level:
  filepath: marmara_sea_level-100.csv
```
The first sea-level file, *marmara_sea_level.csv*, will be used until the 100th time step when the second sea-level file, *marmara_sea_level-100.csv* will be used.

**Note that not all parameters is a *Sequence* config file can change with time**. Whether or not a parameter can vary with time depends on the component it refers to and if that component allows that parameter to change.