### PR TITLE
Add time varying-parameters for SubmarineDiffuser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog for sequence
 ======================
 
-0.2.1 (unreleased)
+0.3.0 (unreleased)
 ------------------
 
 - Added more time-varying parameters to SubmarineDiffuser (#24)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog for sequence
 0.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added more time-varying parameters to SubmarineDiffuser (#24)
 
 
 0.2.0 (2020-07-30)

--- a/sequence/submarine.py
+++ b/sequence/submarine.py
@@ -98,6 +98,47 @@ class SubmarineDiffuser(LinearDiffuser):
         super(SubmarineDiffuser, self).__init__(grid, **kwds)
 
     @property
+    def plain_slope(self):
+        return self._plain_slope
+
+    @plain_slope.setter
+    def plain_slope(self, value):
+        self._plain_slope = float(value)
+        self._ksh = self._load / self._plain_slope
+
+    @property
+    def wave_base(self):
+        return self._wave_base
+
+    @wave_base.setter
+    def wave_base(self, value):
+        self._wave_base = float(value)
+
+    @property
+    def shoreface_height(self):
+        return self._shoreface_height
+
+    @shoreface_height.setter
+    def shoreface_height(self, value):
+        self._shoreface_height = float(value)
+
+    @property
+    def alpha(self):
+        return self._alpha
+
+    @alpha.setter
+    def alpha(self, value):
+        self._alpha = float(value)
+
+    @property
+    def shelf_slope(self):
+        return self._shelf_slope
+
+    @shelf_slope.setter
+    def shelf_slope(self, value):
+        self._shelf_slope = float(value)
+
+    @property
     def sediment_load(self):
         return self._load0
 

--- a/sequence/submarine.py
+++ b/sequence/submarine.py
@@ -11,26 +11,31 @@ class SubmarineDiffuser(LinearDiffuser):
 
     _time_units = "y"
 
-    _input_var_names = ("topographic__elevation", "sea_level__elevation")
-
-    _output_var_names = ("topographic__elevation", "sediment_deposit__thickness")
-
-    _var_units = {
-        "topographic__elevation": "m",
-        "sea_level__elevation": "m",
-        "sediment_deposit__thickness": "m",
-    }
-
-    _var_mapping = {
-        "topographic__elevation": "node",
-        "sea_level__elevation": "grid",
-        "sediment_deposit__thickness": "node",
-    }
-
-    _var_doc = {
-        "topographic__elevation": "land and ocean bottom elevation, positive up",
-        "sea_level__elevation": "Position of sea level",
-        "sediment_deposit__thickness": "Thickness of deposition or erosion",
+    _info = {
+        "sea_level__elevation": {
+            "dtype": "float",
+            "intent": "in",
+            "optional": False,
+            "units": "m",
+            "mapping": "grid",
+            "doc": "Position of sea level",
+        },
+        "topographic__elevation": {
+            "dtype": "float",
+            "intent": "inout",
+            "optional": False,
+            "units": "m",
+            "mapping": "node",
+            "doc": "land and ocean bottom elevation, positive up",
+        },
+        "sediment_deposit__thickness": {
+            "dtype": "float",
+            "intent": "out",
+            "optional": False,
+            "units": "m",
+            "mapping": "node",
+            "doc": "Thickness of deposition or erosion",
+        },
     }
 
     def __init__(
@@ -147,7 +152,7 @@ class SubmarineDiffuser(LinearDiffuser):
         self._load0 = float(value)
         self._load = self._load0 * (1 + self._sea_level * self._load_sl)
         self._ksh = self._load / self._plain_slope
-        grid.at_grid["sediment_load"] = self._load
+        self.grid.at_grid["sediment_load"] = self._load
 
     @property
     def k0(self):

--- a/sequence/submarine.py
+++ b/sequence/submarine.py
@@ -98,6 +98,17 @@ class SubmarineDiffuser(LinearDiffuser):
         super(SubmarineDiffuser, self).__init__(grid, **kwds)
 
     @property
+    def sediment_load(self):
+        return self._load0
+
+    @sediment_load.setter
+    def sediment_load(self, value):
+        self._load0 = float(value)
+        self._load = self._load0 * (1 + self._sea_level * self._load_sl)
+        self._ksh = self._load / self._plain_slope
+        grid.at_grid["sediment_load"] = self._load
+
+    @property
     def k0(self):
         return self._k0
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ long_description = u'\n\n'.join(
 
 setup(
     name="sequence",
-    version="0.2.1.dev0",
+    version="0.3.0.dev0",
     author="Eric Hutton",
     author_email="mcflugen@gmail.com",
     classifiers=[

--- a/tests/test_submarine_diffuser.py
+++ b/tests/test_submarine_diffuser.py
@@ -1,18 +1,9 @@
 from random import random
 
 import pytest
-from numpy.testing import assert_array_equal
 
 from sequence.submarine import SubmarineDiffuser
 from landlab import RasterModelGrid
-
-
-def test_diffuser():
-    grid = RasterModelGrid((3, 5))
-    grid.add_zeros("topographic__elevation", at="node")
-    grid.at_grid["sea_level__elevation"] = 0.0
-
-    diffuser = SubmarineDiffuser(grid)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_submarine_diffuser.py
+++ b/tests/test_submarine_diffuser.py
@@ -1,0 +1,41 @@
+from random import random
+
+import pytest
+from numpy.testing import assert_array_equal
+
+from sequence.submarine import SubmarineDiffuser
+from landlab import RasterModelGrid
+
+
+def test_diffuser():
+    grid = RasterModelGrid((3, 5))
+    grid.add_zeros("topographic__elevation", at="node")
+    grid.at_grid["sea_level__elevation"] = 0.0
+
+    diffuser = SubmarineDiffuser(grid)
+
+
+@pytest.mark.parametrize(
+    "param",
+    (
+        "plain_slope",
+        "wave_base",
+        "shoreface_height",
+        "alpha",
+        "shelf_slope",
+        "sediment_load",
+    ),
+)
+def test_setters(param):
+    grid = RasterModelGrid((3, 5))
+    grid.add_zeros("topographic__elevation", at="node")
+    grid.at_grid["sea_level__elevation"] = 0.0
+
+    expected = random()
+    diffuser = SubmarineDiffuser(grid, **{param: expected})
+
+    assert getattr(diffuser, param) == pytest.approx(expected)
+
+    expected = random()
+    setattr(diffuser, param, expected)
+    assert getattr(diffuser, param) == pytest.approx(expected)


### PR DESCRIPTION
This pull request adds setters for additional parameters for the *SubmarineDiffuser* component.

There are now setters for the following *SubmarineDiffuser* components:
* plain_slope
* wave_base
* shoreface_height
* alpha
* shelf_slope
* sediment_load

This allows these variables to be changed after the component has been initialized and so can vary as the model advances.