### PR TITLE
Fix interpolating between layers when plotting

### DIFF
--- a/sequence/cli.py
+++ b/sequence/cli.py
@@ -154,7 +154,9 @@ def run(with_citations, verbose, dry_run):
     if verbose:
         out(params.dump())
 
-    model = SequenceModel(**params.as_dict())
+    model_params = params.as_dict()
+    model_params.pop("plot", None)
+    model = SequenceModel(**model_params)
 
     if with_citations:
         from landlab.core.model_component import registry

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from matplotlib.patches import Patch
+from scipy.interpolate import interp1d
 
 
 def pairwise(iterable):
@@ -18,9 +19,9 @@ def pairwise(iterable):
 def plot_strat(
     filename,
     color_water=(0.8, 1.0, 1.0),
-    color_land=(0.8, 1.0, 0.8),
-    color_shoreface=(0.8, 0.8, 0.0),
-    color_shelf=(0.75, 0.5, 0.5),
+    color_land=(0.8, 1.0, 0.8, 0.5),
+    color_shoreface=(0.8, 0.8, 0.0, 0.5),
+    color_shelf=(0.75, 0.5, 0.5, 0.5),
     layer_line_width=0.5,
     layer_line_color="k",
     layer_start=0,
@@ -31,6 +32,10 @@ def plot_strat(
     y_label="Elevation (m)",
     legend_location="lower left",
 ):
+    plot_land = bool(color_land)
+    plot_shoreface = bool(color_shoreface)
+    plot_shelf = bool(color_shelf)
+
     filename = pathlib.Path(filename)
 
     legend_item = partial(Patch, edgecolor="k", linewidth=0.5)
@@ -41,13 +46,30 @@ def plot_strat(
         thickness_at_layer = ds["at_layer:thickness"][:n_times]
         x_of_shore = ds["at_grid:x_of_shore"].data.squeeze()
         x_of_shelf_edge = ds["at_grid:x_of_shelf_edge"].data.squeeze()
-        x_of_stack = ds["x_of_cell"].data.squeeze()
+        # x_of_stack = ds["x_of_cell"].data.squeeze()
         bedrock = ds["at_node:bedrock_surface__elevation"].data.squeeze()
+        try:
+            x_of_stack = ds["x_of_cell"].data.squeeze()
+        except KeyError:
+            x_of_stack = np.arange(ds.dims["cell"])
+            # (
+            #     np.arange(ds.dims["cell"]) * ds["xy_spacing"][0]
+            #     + ds["xy_of_lower_left"][0]
+            # )
 
         elevation_at_layer = bedrock[-1, 1:-1] + np.cumsum(thickness_at_layer, axis=0)
 
     if n_layers:
-        layer_step = int(len(elevation_at_layer) / n_layers)
+        # layer_step = int(len(elevation_at_layer) / (n_layers + 1))
+        if layer_stop < 0:
+            layer_stop = len(elevation_at_layer) + layer_stop
+        if n_layers >= 0:
+            if n_layers > layer_stop - layer_start:
+                layer_step = layer_stop - layer_start - 1
+            else:
+                layer_step = int((layer_stop - layer_start) / (n_layers + 1))
+        else:
+            layer_step = 1
         plt.plot(
             x_of_stack,
             elevation_at_layer[layer_start:layer_stop:layer_step].T,
@@ -59,67 +81,51 @@ def plot_strat(
     x_water = x_of_stack[water]
     y_water = elevation_at_layer[-1, water]
 
-    plt.fill_between(
-        x_water, y_water, np.full_like(x_water, y_water[0]), fc=color_water
-    )
+    if color_water:
+        plt.fill_between(
+            x_water, y_water, np.full_like(x_water, y_water[0]), fc=color_water
+        )
     plt.plot([x_water[0], x_water[-1]], [y_water[0], y_water[0]], color="k")
 
-    stack_of_shore = np.searchsorted(x_of_stack, x_of_shore)
-    land_top = x_of_stack <= x_of_shore[-1]
-    land_bottom = x_of_stack <= x_of_shore[0]
-    plt.fill(
-        np.r_[x_of_shore, x_of_stack[land_top][::-1], x_of_stack[land_bottom]],
-        np.r_[
-            elevation_at_layer.data[np.arange(n_times), stack_of_shore],
-            elevation_at_layer[-1, land_top][::-1],
-            elevation_at_layer[0, land_bottom],
-        ],
-        fc=color_land,
-    )
+    # stack_of_shore = np.searchsorted(x_of_stack, x_of_shore)
+
+    if plot_land:
+        fill_layers(
+            x_of_stack,
+            elevation_at_layer,
+            lower=None,
+            upper=x_of_shore,
+            fc=color_land,
+        )
 
     stack_of_shelf_edge = np.searchsorted(x_of_stack, x_of_shelf_edge)
-    shoreface_top = (x_of_stack > x_of_shore[-1]) & (x_of_stack <= x_of_shelf_edge[-1])
-    shoreface_bottom = (x_of_stack > x_of_shore[0]) & (x_of_stack <= x_of_shelf_edge[0])
-    plt.fill(
-        np.r_[
-            x_of_shelf_edge,
-            x_of_stack[shoreface_top][::-1],
-            x_of_shore[::-1],
-            x_of_stack[shoreface_bottom],
-        ],
-        np.r_[
-            elevation_at_layer.data[np.arange(n_times), stack_of_shelf_edge],
-            elevation_at_layer[-1, shoreface_top][::-1],
-            elevation_at_layer.data[np.arange(n_times), stack_of_shore][::-1],
-            elevation_at_layer[0, shoreface_bottom],
-        ],
-        fc=color_shoreface,
-    )
 
-    shelf_top = x_of_stack > x_of_shelf_edge[-1]
-    shelf_bottom = x_of_stack > x_of_shelf_edge[0]
-    plt.fill(
-        np.r_[
-            x_of_stack[shelf_top][::-1],
-            x_of_shelf_edge[::-1],
-            x_of_stack[shelf_bottom],
-        ],
-        np.r_[
-            elevation_at_layer[-1, shelf_top][::-1],
-            elevation_at_layer.data[np.arange(n_times), stack_of_shelf_edge][::-1],
-            elevation_at_layer[0, shelf_bottom],
-        ],
-        fc=color_shelf,
-    )
+    if plot_shoreface:
+        fill_layers(
+            x_of_stack,
+            elevation_at_layer,
+            lower=x_of_shore,
+            upper=x_of_shelf_edge,
+            fc=color_shoreface,
+        )
+
+    if plot_shelf:
+        fill_layers(
+            x_of_stack,
+            elevation_at_layer,
+            lower=x_of_shelf_edge,
+            upper=None,
+            fc=color_shelf,
+        )
 
     if legend_location:
-        legend = [
-            legend_item(label="Land", fc=color_land),
-            legend_item(label="Shoreface", fc=color_shoreface),
-            legend_item(label="Shelf", fc=color_shelf),
+        items = [
+            ("Land", color_land),
+            ("Shoreface", color_shoreface),
+            ("Shelf", color_shelf),
         ]
-
-        plt.legend(handles=legend, loc=legend_location)
+        legend = [legend_item(label=label, fc=color) for label, color in items if color]
+        legend and plt.legend(handles=legend, loc=legend_location)
 
     plt.xlabel(x_label)
     plt.ylabel(y_label)
@@ -127,3 +133,111 @@ def plot_strat(
     plt.xlim((x_of_stack[0], x_of_stack[-1]))
 
     plt.show()
+
+
+def fill_layers(x, y, lower=None, upper=None, fc=None):
+    n_layers = len(y)
+
+    if lower is None:
+        lower = np.full(n_layers, x[0])
+
+    if upper is None:
+        upper = np.full(n_layers, x[-1])
+
+    for layer in range(n_layers - 1):
+        # for layer in range(1):
+        top = (x > lower[layer + 1]) & (x < upper[layer + 1])
+        bottom = (x > lower[layer]) & (x < upper[layer])
+
+        xi, yi = outline_layer(
+            x,
+            y[layer],
+            y[layer + 1],
+            bottom_limits=(lower[layer], upper[layer]),
+            top_limits=(lower[layer + 1], upper[layer + 1]),
+        )
+        plt.fill(xi, yi, fc=fc)  # , ec="k")
+
+        # plt.plot(x[bottom], y[layer][bottom], linewidth=3)
+        # plt.plot(x[top], y[layer + 1][top], linewidth=3)
+
+
+def outline_layer(
+    x, y_of_bottom_layer, y_of_top_layer, bottom_limits=None, top_limits=None
+):
+    #     bottom_limits = (None, None) if bottom_limits is None else bottom_limits
+    #     top_limits = (None, None) if top_limits is None else top_limits
+    #
+    #     bottom_limits[0] = x[0] if bottom_limits is None else bottom_limits[0]
+    #     bottom_limits[1] = x[1] if bottom_limits is None else bottom_limits[1]
+    #     bottom_limits[0] = x[0] if bottom_limits is None else bottom_limits[0]
+    #     bottom_limits[1] = x[1] if bottom_limits is None else bottom_limits[1]
+
+    if bottom_limits is None:
+        bottom_limits = (x[0], x[1])
+    if top_limits is None:
+        top_limits = (x[0], x[1])
+
+    is_top = (x >= top_limits[0]) & (x <= top_limits[1])
+    x_of_top = x[is_top]
+    y_of_top = y_of_top_layer[is_top]
+
+    is_bottom = (x >= bottom_limits[0]) & (x <= bottom_limits[1])
+    x_of_bottom = x[is_bottom]
+    y_of_bottom = y_of_bottom_layer[is_bottom]
+
+    is_left = (x > min(x_of_top[0], x_of_bottom[0])) & (
+        x < max(x_of_top[0], x_of_bottom[0])
+    )
+    x_of_left = x[is_left]
+    reverse = top_limits[0] > bottom_limits[0]
+    y_of_left = interp_between_layers(
+        x_of_left, y_of_top_layer[is_left], y_of_bottom_layer[is_left], reverse=reverse
+    )
+
+    is_right = (x > min(x_of_top[-1], x_of_bottom[-1])) & (
+        x < max(x_of_top[-1], x_of_bottom[-1])
+    )
+    x_of_right = x[is_right]
+    reverse = top_limits[1] < bottom_limits[1]
+    y_of_right = interp_between_layers(
+        x_of_right,
+        y_of_bottom_layer[is_right],
+        y_of_top_layer[is_right],
+        reverse=reverse,
+    )
+
+    if top_limits[0] > bottom_limits[0]:
+        x_of_left = x_of_left[::-1]
+        y_of_left = y_of_left[::-1]
+    if top_limits[-1] < bottom_limits[-1]:
+        x_of_right = x_of_right[::-1]
+        y_of_right = y_of_right[::-1]
+
+    return (
+        np.r_[x_of_top[::-1], x_of_left, x_of_bottom, x_of_right],
+        np.r_[y_of_top[::-1], y_of_left, y_of_bottom, y_of_right],
+    )
+
+
+def interp_between_layers(x, y_of_bottom, y_of_top, kind="linear", reverse=False):
+    x = np.asarray(x)
+    y_of_top, y_of_bottom = np.asarray(y_of_top), np.asarray(y_of_bottom)
+
+    assert len(y_of_top) == len(y_of_bottom) == len(x)
+
+    if len(x) == 0:
+        return np.array([], dtype=float)
+    elif len(x) == 1:
+        return (y_of_top + y_of_bottom) * 0.5
+
+    if reverse:
+        dy = (y_of_top - y_of_bottom) * interp1d((x[0], x[-1]), (1.0, 0.0), kind=kind)(
+            x
+        )
+    else:
+        dy = (y_of_top - y_of_bottom) * interp1d((x[0], x[-1]), (0.0, 1.0), kind=kind)(
+            x
+        )
+
+    return y_of_bottom + dy

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_array_almost_equal
+
+from sequence.plot import interp_between_layers, outline_layer
+
+
+def test_layer_interpolation_bottom_to_top():
+    bottom, top = np.zeros(5), np.ones(5)
+    yi = interp_between_layers(np.arange(5), bottom, top)
+
+    assert_array_almost_equal(yi, [0.0, 0.25, 0.5, 0.75, 1.0])
+
+
+def test_layer_interpolation_top_to_bottom():
+    bottom, top = np.zeros(5), np.ones(5)
+
+    yi = interp_between_layers([0.0, 1.0, 2.0, 3.0, 4.0], top, bottom)
+    assert_array_almost_equal(yi, [1.0, 0.75, 0.5, 0.25, 0.0])
+
+
+@pytest.mark.parametrize(
+    "top_limits,bottom_limits,expected",
+    (
+        [(0, 2), (3, 6), [2, 1, 0, 1, 2, 3, 4, 5, 6, 5, 4, 3]],
+        [(2, 4), (3, 6), [4, 3, 2, 3, 4, 5, 6, 5]],
+        [(4, 5), (3, 6), [5, 4, 3, 4, 5, 6]],
+        [(5, 7), (3, 6), [7, 6, 5, 4, 3, 4, 5, 6]],
+        [(8, 9), (3, 6), [9, 8, 7, 6, 5, 4, 3, 4, 5, 6, 7, 8]],
+        [(3, 6), (0, 2), [6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5]],
+        [(3, 6), (2, 4), [6, 5, 4, 3, 2, 3, 4, 5]],
+        [(3, 6), (4, 5), [6, 5, 4, 3, 4, 5]],
+        [(3, 6), (5, 7), [6, 5, 4, 3, 4, 5, 6, 7]],
+        [(3, 6), (8, 9), [6, 5, 4, 3, 4, 5, 6, 7, 8, 9, 8, 7]],
+    ),
+)
+def test_outline_layer_x(top_limits, bottom_limits, expected):
+    x, bottom, top = np.arange(10.0), np.zeros(10), np.ones(10)
+    x_of_patch, y_of_patch = outline_layer(
+        x, bottom, top, bottom_limits=bottom_limits, top_limits=top_limits
+    )
+    assert_array_almost_equal(x_of_patch, expected)
+
+
+def test_outline_layer_y():
+    bottom_limits = (1, 3)
+    top_limits = (5, 9)
+    y_expected = [1, 1, 1, 1, 0.5, 0.5, 0.5, 0.5, 0, 0, 0, 0.5, 0.5, 0.5, 0.5, 0.5]
+    x_expected = [9, 8, 7, 6, 5, 4, 3, 2, 1, 2, 3, 4, 5, 6, 7, 8]
+
+    x, bottom, top = np.arange(10.0), np.zeros(10), np.ones(10)
+    x_of_patch, y_of_patch = outline_layer(
+        x, bottom, top, bottom_limits=bottom_limits, top_limits=top_limits
+    )
+    assert_array_almost_equal(x_of_patch, x_expected)
+    assert_array_almost_equal(y_of_patch, y_expected)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -42,15 +42,98 @@ def test_outline_layer_x(top_limits, bottom_limits, expected):
     assert_array_almost_equal(x_of_patch, expected)
 
 
-def test_outline_layer_y():
-    bottom_limits = (1, 3)
-    top_limits = (5, 9)
-    y_expected = [1, 1, 1, 1, 0.5, 0.5, 0.5, 0.5, 0, 0, 0, 0.5, 0.5, 0.5, 0.5, 0.5]
-    x_expected = [9, 8, 7, 6, 5, 4, 3, 2, 1, 2, 3, 4, 5, 6, 7, 8]
-
+@pytest.mark.parametrize(
+    "top_limits,bottom_limits,expected",
+    (
+        [
+            (1, 3),
+            (5, 8),
+            [1, 1, 1, 0.75, 0.5, 0.25, 0, 0, 0, 0, 0.2, 0.4, 0.6, 0.8],
+        ],
+        [(1, 4), (3, 8), [1, 1, 1, 1, 0.5, 0, 0, 0, 0, 0, 0, 0.25, 0.5, 0.75]],
+        [(3, 6), (1, 8), [1, 1, 1, 1, 0.5, 0, 0, 0, 0, 0, 0, 0, 0, 0.5]],
+        [(3, 9), (1, 5), [1, 1, 1, 1, 1, 1, 1, 0.5, 0, 0, 0, 0, 0, 0.25, 0.5, 0.75]],
+        [(7, 9), (3, 5), [1, 1, 1, 0.75, 0.5, 0.25, 0, 0, 0, 0.25, 0.5, 0.75]],
+    ),
+)
+def test_outline_layer_y(top_limits, bottom_limits, expected):
     x, bottom, top = np.arange(10.0), np.zeros(10), np.ones(10)
+    _, y_of_patch = outline_layer(
+        x, bottom, top, bottom_limits=bottom_limits, top_limits=top_limits
+    )
+    assert_array_almost_equal(y_of_patch, expected)
+
+
+def test_outline_layer_without_sides():
+    x, bottom, top = np.arange(10.0), np.zeros(10), np.ones(10)
+    x_of_patch, y_of_patch = outline_layer(
+        x, bottom, top, bottom_limits=(1, 5), top_limits=(1, 5)
+    )
+    assert_array_almost_equal(x_of_patch, [5, 4, 3, 2, 1, 2, 3, 4])
+    assert_array_almost_equal(y_of_patch, [1, 1, 1, 1, 0, 0, 0, 0])
+
+
+def test_outline_layer_without_bottom():
+    x, bottom, top = np.arange(10.0), np.zeros(10), np.ones(10)
+    x_of_patch, y_of_patch = outline_layer(
+        x, bottom, top, bottom_limits=(5, 5), top_limits=(4, 6)
+    )
+    assert_array_almost_equal(x_of_patch, [6, 5, 4, 5])
+    assert_array_almost_equal(y_of_patch, [1, 1, 1, 0])
+
+    x_of_patch, y_of_patch = outline_layer(
+        x, bottom, top, bottom_limits=(5, 5), top_limits=(0, 3)
+    )
+    assert_array_almost_equal(x_of_patch, [3, 2, 1, 0, 1, 2, 3, 4, 5, 4])
+    assert_array_almost_equal(y_of_patch, [1, 1, 1, 1, 0.8, 0.6, 0.4, 0.2, 0, 0.5])
+
+    x_of_patch, y_of_patch = outline_layer(
+        x, bottom, top, bottom_limits=(5, 5), top_limits=(6, 9)
+    )
+    assert_array_almost_equal(x_of_patch, [9, 8, 7, 6, 5, 6, 7, 8])
+    assert_array_almost_equal(y_of_patch, [1, 1, 1, 1, 0, 0.25, 0.5, 0.75])
+
+
+def test_outline_layer_without_top():
+    x, bottom, top = np.arange(10.0), np.zeros(10), np.ones(10)
+    x_of_patch, y_of_patch = outline_layer(
+        x, bottom, top, bottom_limits=(4, 6), top_limits=(5, 5)
+    )
+    assert_array_almost_equal(x_of_patch, [5, 4, 5, 6])
+    assert_array_almost_equal(y_of_patch, [1, 0, 0, 0])
+
+    x_of_patch, y_of_patch = outline_layer(
+        x, bottom, top, bottom_limits=(0, 3), top_limits=(5, 5)
+    )
+    assert_array_almost_equal(x_of_patch, [5, 4, 3, 2, 1, 0, 1, 2, 3, 4])
+    assert_array_almost_equal(y_of_patch, [1, 0.8, 0.6, 0.4, 0.2, 0, 0, 0, 0, 0.5])
+
+    x_of_patch, y_of_patch = outline_layer(
+        x, bottom, top, bottom_limits=(6, 9), top_limits=(5, 5)
+    )
+    assert_array_almost_equal(x_of_patch, [5, 6, 7, 8, 9, 8, 7, 6])
+    assert_array_almost_equal(y_of_patch, [1, 0, 0, 0, 0, 0.25, 0.5, 0.75])
+
+
+def test_outline_layer_tiny():
+    x, bottom, top = np.arange(10.0), np.zeros(10), np.ones(10)
+    x_of_patch, y_of_patch = outline_layer(
+        x, bottom, top, bottom_limits=(4, 5), top_limits=(4, 5)
+    )
+    assert_array_almost_equal(x_of_patch, [5, 4])
+    assert_array_almost_equal(y_of_patch, [1, 0])
+
+
+@pytest.mark.parametrize("bottom_limits", [(0, None), (None, 9), (None, None), None])
+@pytest.mark.parametrize("top_limits", [(0, None), (None, 9), (None, None), None])
+def test_outline_layer_no_limits(bottom_limits, top_limits):
+    x, bottom, top = np.arange(10.0), np.zeros(10), np.ones(10)
+    x_expected, y_expected = outline_layer(
+        x, bottom, top, bottom_limits=(0, 9), top_limits=(0, 9)
+    )
     x_of_patch, y_of_patch = outline_layer(
         x, bottom, top, bottom_limits=bottom_limits, top_limits=top_limits
     )
+
     assert_array_almost_equal(x_of_patch, x_expected)
     assert_array_almost_equal(y_of_patch, y_expected)


### PR DESCRIPTION
This pull request adds layer interpolation when plotting layers. Plots of output that contained large changes of the position of the shoreface or shelf edge from one layer to the next would occasionally show interpolation artifacts where the positions between layers were joined by straight lines. With this pull request, lines joining the shoreface and shelf edge positions between layers are now better interpolated—points are interpolated linearly *within* each layer.