### PR TITLE
Fix core dump when using numpy v1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Build and install package
         run: |
+          conda install rasterio -c conda-forge
           conda install --file=requirements.txt -c conda-forge
           pip install .
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,9 +92,9 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"sequence"
-copyright = u"2018, Eric Hutton"
-author = u"Eric Hutton"
+project = "sequence"
+copyright = "2018, Eric Hutton"
+author = "Eric Hutton"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -171,7 +171,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "sequence.tex", u"sequence Documentation", u"Eric Hutton", "manual")
+    (master_doc, "sequence.tex", "sequence Documentation", "Eric Hutton", "manual")
 ]
 
 
@@ -179,7 +179,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "sequence", u"sequence Documentation", [author], 1)]
+man_pages = [(master_doc, "sequence", "sequence Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -191,7 +191,7 @@ texinfo_documents = [
     (
         master_doc,
         "sequence",
-        u"sequence Documentation",
+        "sequence Documentation",
         author,
         "sequence",
         "One line description of project.",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 click
 compaction
-landlab>=2.0.0b7
+landlab
 netcdf4
-numpy<1.21
+numpy
 pyyaml
 scipy
 tomlkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click
 compaction
 landlab
 netcdf4
-numpy
+numpy != 1.21.0, != 1.21.1
 pyyaml
 scipy
 tomlkit

--- a/sequence/fluvial.py
+++ b/sequence/fluvial.py
@@ -99,7 +99,7 @@ class Fluvial(Component):
         qs = (
             10.0
             * np.sqrt(9.8 * (self.sand_density / 1000.0 - 1.0))
-            * (self.sand_grain ** 1)
+            * (self.sand_grain**1)
         )
         # m^2/s  units */
         # print (self.sand_frac,mud_vol,sand_vol,qs)

--- a/sequence/sequence_model.py
+++ b/sequence/sequence_model.py
@@ -3,10 +3,9 @@
 from collections import OrderedDict
 
 import numpy as np
+from compaction.landlab import Compact
 from landlab import RasterModelGrid
 from landlab.bmi.bmi_bridge import TimeStepper
-
-from compaction.landlab import Compact
 
 from .bathymetry import BathymetryReader
 from .fluvial import Fluvial

--- a/sequence/sequence_model.py
+++ b/sequence/sequence_model.py
@@ -163,7 +163,7 @@ class SequenceModel:
         self._components.update(
             sea_level=self._sea_level,
             subsidence=self._subsidence,
-            compaction=self._compaction,
+            # compaction=self._compaction,
             submarine_diffusion=self._submarine_diffusion,
             fluvial=self._fluvial,
             flexure=self._flexure,
@@ -221,7 +221,7 @@ class SequenceModel:
             water_depth=water_depth[self.grid.node_at_cell],
             t0=dz[self.grid.node_at_cell].clip(0.0),
             percent_sand=percent_sand[self.grid.node_at_cell],
-            porosity=self._compaction.porosity_max,
+            # porosity=self._compaction.porosity_max,
         )
 
         try:

--- a/sequence/sequence_model.py
+++ b/sequence/sequence_model.py
@@ -162,7 +162,7 @@ class SequenceModel:
         self._components.update(
             sea_level=self._sea_level,
             subsidence=self._subsidence,
-            # compaction=self._compaction,
+            compaction=self._compaction,
             submarine_diffusion=self._submarine_diffusion,
             fluvial=self._fluvial,
             flexure=self._flexure,
@@ -220,7 +220,7 @@ class SequenceModel:
             water_depth=water_depth[self.grid.node_at_cell],
             t0=dz[self.grid.node_at_cell].clip(0.0),
             percent_sand=percent_sand[self.grid.node_at_cell],
-            # porosity=self._compaction.porosity_max,
+            porosity=self._compaction.porosity_max,
         )
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(filename):
         return fp.read()
 
 
-long_description = u"\n\n".join(
+long_description = "\n\n".join(
     [
         read("README.rst"),
         read("AUTHORS.rst"),

--- a/tests/test_sequence_model.py
+++ b/tests/test_sequence_model.py
@@ -7,7 +7,7 @@ from landlab.core import load_params
 from sequence.sequence_model import SequenceModel
 
 
-@pytest.mark.skip("test fails with a core dump from numpy")
+# @pytest.mark.skip("test fails with a core dump from numpy")
 def test_marmara(tmpdir, datadir):
     with tmpdir.as_cwd():
         for fname in datadir.iterdir():

--- a/tests/test_sequence_model.py
+++ b/tests/test_sequence_model.py
@@ -1,11 +1,13 @@
 import os
 import shutil
 
+import pytest
 from landlab.core import load_params
 
 from sequence.sequence_model import SequenceModel
 
 
+@pytest.mark.skip("test fails with a core dump from numpy")
 def test_marmara(tmpdir, datadir):
     with tmpdir.as_cwd():
         for fname in datadir.iterdir():

--- a/tests/test_sequence_model.py
+++ b/tests/test_sequence_model.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 
-import pytest
 from landlab.core import load_params
 
 from sequence.sequence_model import SequenceModel

--- a/tests/test_submarine_diffuser.py
+++ b/tests/test_submarine_diffuser.py
@@ -1,9 +1,9 @@
 from random import random
 
 import pytest
+from landlab import RasterModelGrid
 
 from sequence.submarine import SubmarineDiffuser
-from landlab import RasterModelGrid
 
 
 @pytest.mark.parametrize(

--- a/tests/test_subsidence.py
+++ b/tests/test_subsidence.py
@@ -1,8 +1,8 @@
 import pytest
+from landlab import RasterModelGrid
 from numpy.testing import assert_array_equal
 
 from sequence.subsidence import SubsidenceTimeSeries
-from landlab import RasterModelGrid
 
 
 def test_bad_filepath(tmpdir):


### PR DESCRIPTION
This pull request tries to fix a core dump error with the message *"double free or corruption"*. #30 "fixed" the issue by requiring *numpy<1.21* but that wasn't really a fix—it's not clear if the problem lies in *numpy* or *landlab* or *sequence* (or somewhere else). If possible, it would be nice if we didn't have to limit the *numpy* version.