### PR TITLE
Fix time variable in netcdf output

### DIFF
--- a/news/34.bugfix
+++ b/news/34.bugfix
@@ -1,0 +1,4 @@
+Fixed a bug where, instead of writing the current model time, *Sequence* was
+writing the model time step number to the output file as the *time* variable.
+
+

--- a/sequence/output_writer.py
+++ b/sequence/output_writer.py
@@ -37,15 +37,19 @@ class OutputWriter(Component):
         else:
             self._nodes = None
 
+        self._time = 0.0
         self._step_count = 0
 
     def run_one_step(self, dt=None):
+        if dt is None:
+            dt = 1
+        self._time += dt
         if self._step_count % self.interval == 0:
             to_netcdf(
                 self.grid,
                 self.filepath,
                 mode="a",
-                time=self._step_count,
+                time=self._time,
                 names={"node": self.fields},
                 ids={"node": self._nodes},
             )

--- a/sequence/output_writer.py
+++ b/sequence/output_writer.py
@@ -41,9 +41,7 @@ class OutputWriter(Component):
         self._step_count = 0
 
     def run_one_step(self, dt=None):
-        if dt is None:
-            dt = 1
-        self._time += dt
+        dt = 1.0 if dt is None else float(dt)
         if self._step_count % self.interval == 0:
             to_netcdf(
                 self.grid,
@@ -53,6 +51,7 @@ class OutputWriter(Component):
                 names={"node": self.fields},
                 ids={"node": self._nodes},
             )
+        self._time += dt
         self._step_count += 1
 
     @property


### PR DESCRIPTION
This pull request addresses #34 where *Sequence* was writing the time step number rather than the time to the *netCDF* output file.