### PR TITLE
Interpolate model time to layer age

### DIFF
--- a/37.bugfix
+++ b/37.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug that incorrectly determined the shore and shelf edge at startigraphic layers
+when writing *netCDF* output. This was only an issue when *Sequence* had averaged buried layers.

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -43,7 +43,7 @@ def plot_strat(
     with xr.open_dataset(filename) as ds:
         n_times = ds.dims["time"]
 
-        thickness_at_layer = ds["at_layer:thickness"][:n_times]
+        thickness_at_layer = ds["at_layer:thickness"]
         x_of_shore = ds["at_grid:x_of_shore"].data.squeeze()
         x_of_shelf_edge = ds["at_grid:x_of_shelf_edge"].data.squeeze()
         bedrock = ds["at_node:bedrock_surface__elevation"].data.squeeze()
@@ -51,8 +51,13 @@ def plot_strat(
             x_of_stack = ds["x_of_cell"].data.squeeze()
         except KeyError:
             x_of_stack = np.arange(ds.dims["cell"])
+        time = ds["time"]
+        time_at_layer = ds["at_layer:age"]
 
         elevation_at_layer = bedrock[-1, 1:-1] + np.cumsum(thickness_at_layer, axis=0)
+
+    x_of_shore = interp1d(time, x_of_shore)(time_at_layer[:, 0])
+    x_of_shelf_edge = interp1d(time, x_of_shelf_edge)(time_at_layer[:, 0])
 
     stack_of_shore = np.searchsorted(x_of_stack, x_of_shore)
     stack_of_shelf_edge = np.searchsorted(x_of_stack, x_of_shelf_edge)

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -41,8 +41,6 @@ def plot_strat(
     legend_item = partial(Patch, edgecolor="k", linewidth=0.5)
 
     with xr.open_dataset(filename) as ds:
-        n_times = ds.dims["time"]
-
         thickness_at_layer = ds["at_layer:thickness"]
         x_of_shore = ds["at_grid:x_of_shore"].data.squeeze()
         x_of_shelf_edge = ds["at_grid:x_of_shelf_edge"].data.squeeze()


### PR DESCRIPTION
This pull request fixes an issue when plotting *Sequence* output that contains layers that have been averaged.

The *Sequence* output file contains variables at every time step (e.g. the position of the shelf edge) as well as variables for every sediment layer (e.g. sediment porosity, layer thickness, age). When plotting stratigraphy it's important to match up shore line location (and shelf edge location) to the correct layer. If layers have not been combined, this is easy: the location of the shore line at time *n* corresponds to the *n*th layer. If layers have been averaged, however, we need to interpolate the shore line location time series to the ages of the combined layers.