### PR TITLE
Fix plotting profiles without water

### DIFF
--- a/news/40.bugfix
+++ b/news/40.bugfix
@@ -1,0 +1,3 @@
+Fixed a bug that caused the ``sequence plot`` command to fail if the entire profile
+was above sea level.
+

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -74,11 +74,12 @@ def plot_strat(
         layer_stop = len(elevation_at_layer) + layer_stop + 1
     layers_to_plot = _get_layers_to_plot(layer_start, layer_stop, num=n_layers)
 
-    if color_water:
-        plt.fill_between(
-            x_water, y_water, np.full_like(x_water, y_water[0]), fc=color_water
-        )
-    plt.plot([x_water[0], x_water[-1]], [y_water[0], y_water[0]], color="k")
+    if np.any(water):
+        if color_water:
+            plt.fill_between(
+                x_water, y_water, np.full_like(x_water, y_water[0]), fc=color_water
+            )
+        plt.plot([x_water[0], x_water[-1]], [y_water[0], y_water[0]], color="k")
 
     if plot_land:
         fill_between_layers(


### PR DESCRIPTION
Fixes #40 by first checking if profile is at least partially underwater before trying to plot water.