### PR TITLE
Fix a bug where the sea floor is sometimes not plotted

### DIFF
--- a/news/46.bugfix
+++ b/news/46.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug where the sea floor was not plotted in some situations.
+

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -109,13 +109,18 @@ def plot_strat(
         )
 
     if layers_to_plot:
-
         plt.plot(
             x_of_stack,
             elevation_at_layer[layers_to_plot].T,
             color=layer_line_color,
             linewidth=layer_line_width,
         )
+    plt.plot(
+        x_of_stack,
+        elevation_at_layer[-1],
+        color=layer_line_color,
+        linewidth=layer_line_width,
+    )
 
     if legend_location:
         items = [


### PR DESCRIPTION
This pull request fixes a bug where the sea floor wasn't plotted in some circumstances. If the total number of layers was not a multiple of the layer interval to plot, the sea floor was left out. I've fixed this so that, regardless of the requested layers to plot, the sea floor is always plotted.