### PR TITLE
Add precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,43 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 22.1.0
+  hooks:
+  - id: black
+    name: black
+    description: "Black: The uncompromising Python code formatter"
+    entry: black
+    language: python
+    language_version: python3
+    minimum_pre_commit_version: 2.9.2
+    require_serial: true
+    types_or: [python, pyi]
+#   - id: black-jupyter
+#     name: black-jupyter
+#     description:
+#       "Black: The uncompromising Python code formatter (with Jupyter Notebook support)"
+#     entry: black
+#     language: python
+#     minimum_pre_commit_version: 2.9.2
+#     require_serial: true
+#     types_or: [python, pyi, jupyter]
+#     additional_dependencies: [".[jupyter]"]
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+    # additional_dependencies: [flake8-bugbear]
+# - repo: https://gitlab.com/iamlikeme/nbhooks
+#   rev: 1.0.0
+#   hooks:
+#   - id: nb-ensure-clean
+#     name: nb-ensure-clean
+#     description: Ensure that committed Jupyter notebooks contain no outputs.
+#     entry: nb-ensure-clean
+#     files: \.ipynb$
+#     language: python
+#     language_version: python3
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.34.0
+  hooks:
+  -   id: pyupgrade
+      args: [--py38-plus]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # sequence documentation build configuration file, created by
 # sphinx-quickstart on Fri Jun  9 13:47:02 2017.
@@ -22,6 +21,8 @@ import os
 import sys
 
 from unittest.mock import MagicMock
+
+import sequence
 
 
 class Mock(MagicMock):
@@ -54,8 +55,6 @@ if os.environ.get("READTHEDOCS", ""):
 
     subprocess.run(["sphinx-apidoc", "--force", "-o", "./api", "../sequence", "*tests"])
 
-
-import sequence
 
 # -- General configuration ---------------------------------------------
 

--- a/news/48.misc
+++ b/news/48.misc
@@ -1,0 +1,3 @@
+Setup of pre-commit for the project that runs *black*, *flake8*, and
+*pyupgrade* (for Python 3.8+).
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
   "black",
   "flake8",
   "isort",
+  "pre-commit",
   "pytest",
   "pytest-cov",
   "pytest-datadir",

--- a/requirements.py
+++ b/requirements.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 import argparse
 import os
-import sys
 
 
 def _find_tomllib():


### PR DESCRIPTION
This pull request setup up *pre-commit* hooks for *sequence*. I've disabled any notebook testing for now but will add that in the (near?) future when we get some more notebooks in the repository. For now, I've turned on *black*, *flake8*, and *pyupgrade* (with `--py38-plus`).