### PR TITLE
Setup PyPI and TestPyPI release actions

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,46 @@
+name: TestPyPI
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+[ab][0-9]+'
+
+env:
+  TWINE_USERNAME: __token__
+  TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+  TWINE_REPOSITORY_URL: 'https://test.pypi.org/legacy/'
+
+jobs:
+  build-and-publish:
+    name: Build and publish to TestPyPI
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      
+      - name: Install twine
+        run: |
+          pip install --upgrade pip wheel setuptools
+          pip install twine
+          python --version
+          pip --version
+          twine --version
+        
+      - name: Create source distribution
+        run: |
+          python setup.py sdist --dist-dir wheelhouse
+        
+      - name: Upload source distribution
+        run: |
+          twine upload --skip-existing wheelhouse/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: PyPI
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '!v[0-9]+.[0-9]+.[0-9]+[ab][0-9]+'
+
+env:
+  TWINE_USERNAME: __token__
+  TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      
+      - name: Install twine
+        run: |
+          pip install --upgrade pip wheel setuptools
+          pip install twine
+          python --version
+          pip --version
+          twine --version
+        
+      - name: Create source distribution
+        run: |
+          python setup.py sdist --dist-dir wheelhouse
+        
+      - name: Upload source distribution
+        run: |
+          twine upload --skip-existing wheelhouse/*.tar.gz

--- a/news/49.misc
+++ b/news/49.misc
@@ -1,0 +1,4 @@
+Added GitHub Actions workflows for releasing Sequence to PyPI and TestPyPI
+(for pre-releases). This allows users to run ``pip install sequence`` to get
+the latest release.
+


### PR DESCRIPTION
This pull request adds two new Github Actions workflows, *release* and *prerelease*, deploy source distributions of *sequence* to PyPI (on tags that look like version numbers) and TestPyPI (on tags that look like version numbers but end with something like `[ab][0-9]+`, e.g. *v1.0.0b1*).

Before pushing releases to PyPI, though, we need to decided on a name that is available on both PyPI and conda-forge (*sequence* is taken).