### PR TITLE
Add Sequence class

### DIFF
--- a/news/50.feature
+++ b/news/50.feature
@@ -1,0 +1,3 @@
+Added ``Sequence`` class that allows a user to construct and run *sequence*
+models within a Python environment and dynamically change input variables.
+

--- a/news/50.feature.1
+++ b/news/50.feature.1
@@ -1,0 +1,3 @@
+Added a ``SequenceModelGrid`` class, based on a *landlab* ``RasterModelGrid``,
+that creates a grid that can be used for creating new *sequence* models.
+

--- a/news/50.feature.2
+++ b/news/50.feature.2
@@ -1,0 +1,4 @@
+Added a new function, ``plot_grid``, that plots the output of a *sequence*
+model from Python. This serves as the programmatic equivalent of the
+``sequence plot`` command-line program.
+

--- a/news/50.feature.3
+++ b/news/50.feature.3
@@ -1,0 +1,2 @@
+Added a new module ``sequence.processes`` that holds all processes that can
+be used to construct a new *sequence* model.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "compaction",
   "landlab",
   "netcdf4",
-  "numpy >=1.21, != 1.21.0, != 1.21.1",
+  "numpy >=1.22",
   "pyyaml",
   "rich-click",
   "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,12 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "click",
   "compaction",
   "landlab",
   "netcdf4",
   "numpy >=1.21, != 1.21.0, != 1.21.1",
   "pyyaml",
+  "rich-click",
   "scipy",
   "tomlkit",
 ]
@@ -72,6 +72,7 @@ doc = [
 
 [project.scripts]
 sequence = "sequence.cli:sequence"
+testy = "sequence.testy:app"
 
 [tool.setuptools]
 packages = ["sequence"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,12 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
+  "click",
   "compaction",
   "landlab",
   "netcdf4",
   "numpy >=1.22",
   "pyyaml",
-  "rich-click",
   "scipy",
   "tomlkit",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 # Requirements extracted from pyproject.toml
 # [project.dependencies]
-click
 compaction
 landlab
 netcdf4
-numpy >=1.21, != 1.21.0, != 1.21.1
+numpy >=1.22
 pyyaml
+rich-click
 scipy
 tomlkit

--- a/sequence/__init__.py
+++ b/sequence/__init__.py
@@ -1,7 +1,15 @@
-import pkg_resources
-
+from ._version import __version__
+from .grid import SequenceModelGrid
 from .output_writer import OutputWriter
+from .sequence import Sequence
 from .submarine import SubmarineDiffuser
 
-__version__ = pkg_resources.get_distribution("sequence").version
-__all__ = ["OutputWriter", "SubmarineDiffuser"]
+__all__ = [
+    "__version__",
+    "OutputWriter",
+    "Sequence",
+    "SubmarineDiffuser",
+    "SeaLevelTimeSeries",
+    "SequenceModelGrid",
+    "SinusoidalSeaLevel",
+]

--- a/sequence/cli.py
+++ b/sequence/cli.py
@@ -4,10 +4,10 @@ import re
 from io import StringIO
 from typing import Any, Optional
 
-# import click
+import click
 import numpy as np
 
-import rich_click as click
+# import rich_click as click
 import tomlkit as toml
 import yaml
 
@@ -18,17 +18,17 @@ from .raster_model import load_model_params, load_params_from_strings
 from .sequence_model import SequenceModel
 
 
-click.rich_click.ERRORS_SUGGESTION = (
-    "Try running the '--help' flag for more information."
-)
-click.rich_click.ERRORS_EPILOGUE = (
-    "To find out more, visit https://github.com/sequence-dev/sequence"
-)
-click.STYLE_ERRORS_SUGGESTION = "yellow italic"
-click.SHOW_ARGUMENTS = True
-click.GROUP_ARGUMENTS_OPTIONS = False
-click.SHOW_METAVARS_COLUMN = True
-click.USE_MARKDOWN = True
+# click.rich_click.ERRORS_SUGGESTION = (
+#     "Try running the '--help' flag for more information."
+# )
+# click.rich_click.ERRORS_EPILOGUE = (
+#     "To find out more, visit https://github.com/sequence-dev/sequence"
+# )
+# click.STYLE_ERRORS_SUGGESTION = "yellow italic"
+# click.SHOW_ARGUMENTS = True
+# click.GROUP_ARGUMENTS_OPTIONS = False
+# click.SHOW_METAVARS_COLUMN = True
+# click.USE_MARKDOWN = True
 
 # out = partial(click.secho, bold=True, file=sys.stderr)
 # err = partial(click.secho, fg="red", file=sys.stderr)

--- a/sequence/cli.py
+++ b/sequence/cli.py
@@ -4,16 +4,31 @@ import re
 from io import StringIO
 from typing import Any, Optional
 
-import click
+# import click
 import numpy as np
+
+import rich_click as click
 import tomlkit as toml
 import yaml
 
 from .errors import MissingRequiredVariable
 from .input_reader import TimeVaryingConfig
-from .plot import plot_strat
+from .plot import plot_file
 from .raster_model import load_model_params, load_params_from_strings
 from .sequence_model import SequenceModel
+
+
+click.rich_click.ERRORS_SUGGESTION = (
+    "Try running the '--help' flag for more information."
+)
+click.rich_click.ERRORS_EPILOGUE = (
+    "To find out more, visit https://github.com/sequence-dev/sequence"
+)
+click.STYLE_ERRORS_SUGGESTION = "yellow italic"
+click.SHOW_ARGUMENTS = True
+click.GROUP_ARGUMENTS_OPTIONS = False
+click.SHOW_METAVARS_COLUMN = True
+click.USE_MARKDOWN = True
 
 # out = partial(click.secho, bold=True, file=sys.stderr)
 # err = partial(click.secho, fg="red", file=sys.stderr)
@@ -169,17 +184,17 @@ class silent_progressbar:
 def sequence(cd, silent, verbose) -> None:
     """The Steckler Sequence model.
 
-    \b
-    Examples:
+    # Examples
 
-      Create a folder with example input files,
-
-        $ mkdir sequence-example && cd sequence-example
-        $ sequence setup
-
-      Run a simulation using the examples input files,
-
-        $ sequence run
+    Create a folder with example input files,
+    ```bash
+    $ mkdir sequence-example && cd sequence-example
+    $ sequence setup
+    ```
+    Run a simulation using the examples input files,
+    ```bash
+    $ sequence run
+    ```
     """
     # if silent:
     #     out.keywords["file"] = open(os.devnull, "w")
@@ -302,7 +317,7 @@ def setup(set):
     "-v", "--verbose", is_flag=True, help="Also emit status messages to stderr."
 )
 def plot(set, verbose):
-    """Plot a sequence output file."""
+    """Plot a Sequence output file."""
     folder = pathlib.Path.cwd()
 
     if (folder / "sequence.toml").exists():
@@ -319,7 +334,7 @@ def plot(set, verbose):
         out(toml.dumps(dict(sequence=dict(plot=config))))
 
     try:
-        plot_strat(folder / "sequence.nc", **config)
+        plot_file(folder / "sequence.nc", **config)
     except MissingRequiredVariable as error:
         err(
             f"{folder / 'sequence.nc'}: output file is missing a required variable ({error})"

--- a/sequence/fluvial.py
+++ b/sequence/fluvial.py
@@ -41,7 +41,7 @@ class Fluvial(Component):
     def __init__(
         self,
         grid,
-        sand_frac,
+        sand_frac=0.5,
         start=0.0,
         wave_base=60.0,
         sediment_load=3.0,
@@ -59,7 +59,7 @@ class Fluvial(Component):
         grid: ModelGrid
             A landlab grid.
         sand_frac: str
-            Name of csv-formatted sea-level file.
+            Fraction of sand on the delta.
         sea_level: float, optional
             The current sea level (m).
         wave_base: float, optional

--- a/sequence/grid.py
+++ b/sequence/grid.py
@@ -1,0 +1,9 @@
+from landlab import RasterModelGrid
+
+
+class SequenceModelGrid(RasterModelGrid):
+    def __init__(self, n_cols, spacing=100.0):
+        super().__init__((3, n_cols), xy_spacing=spacing)
+
+        self.status_at_node[self.nodes_at_top_edge] = self.BC_NODE_IS_CLOSED
+        self.status_at_node[self.nodes_at_bottom_edge] = self.BC_NODE_IS_CLOSED

--- a/sequence/processes.py
+++ b/sequence/processes.py
@@ -1,0 +1,20 @@
+from compaction.landlab import Compact
+
+from .fluvial import Fluvial
+from .sea_level import SeaLevelTimeSeries, SinusoidalSeaLevel
+from .sediment_flexure import SedimentFlexure
+from .shoreline import ShorelineFinder
+from .submarine import SubmarineDiffuser
+from .subsidence import SubsidenceTimeSeries
+
+
+__all__ = [
+    "Compact",
+    "Fluvial",
+    "SeaLevelTimeSeries",
+    "SinusoidalSeaLevel",
+    "SedimentFlexure",
+    "ShorelineFinder",
+    "SubmarineDiffuser",
+    "SubsidenceTimeSeries",
+]

--- a/sequence/sediment_flexure.py
+++ b/sequence/sediment_flexure.py
@@ -14,7 +14,7 @@ class SedimentFlexure(Flexure1D):
         "sediment_deposit__thickness": {
             "dtype": "float",
             "intent": "in",
-            "optional": False,
+            "optional": True,
             "units": "m",
             "mapping": "node",
             "doc": "Thickness of deposited or eroded sediment",
@@ -30,7 +30,7 @@ class SedimentFlexure(Flexure1D):
         "topographic__elevation": {
             "dtype": "float",
             "intent": "inout",
-            "optional": False,
+            "optional": True,
             "units": "m",
             "mapping": "node",
             "doc": "land and ocean bottom elevation, positive up",
@@ -38,7 +38,7 @@ class SedimentFlexure(Flexure1D):
         "bedrock_surface__elevation": {
             "dtype": "float",
             "intent": "inout",
-            "optional": False,
+            "optional": True,
             "units": "m",
             "mapping": "node",
             "doc": "New bedrock elevation following subsidence",
@@ -46,15 +46,15 @@ class SedimentFlexure(Flexure1D):
         "bedrock_surface__increment_of_elevation": {
             "dtype": "float",
             "intent": "out",
-            "optional": False,
+            "optional": True,
             "units": "m",
             "mapping": "node",
             "doc": "Amount of subsidence due to sediment loading",
         },
         "delta_sediment_sand__volume_fraction": {
             "dtype": "float",
-            "intent": "out",
-            "optional": False,
+            "intent": "in",
+            "optional": True,
             "units": "-",
             "mapping": "node",
             "doc": "delta sand fraction",
@@ -111,6 +111,10 @@ class SedimentFlexure(Flexure1D):
             grid.add_empty("lithosphere_surface__increment_of_elevation", at="node")
         if "sea_level__elevation" not in grid.at_grid:
             grid.at_grid["sea_level__elevation"] = 0.0
+        if "delta_sediment_sand__volume_fraction" not in grid.at_node:
+            grid.add_ones("delta_sediment_sand__volume_fraction", at="node")
+        if "bedrock_surface__increment_of_elevation" not in grid.at_node:
+            grid.add_empty("bedrock_surface__increment_of_elevation", at="node")
 
         self.subs_pool = self.grid.zeros(at="node")
 

--- a/sequence/sequence.py
+++ b/sequence/sequence.py
@@ -1,0 +1,144 @@
+import numpy as np
+
+from landlab import Component
+from landlab.layers import EventLayers
+
+
+class Sequence(Component):
+    _name = "Sequence"
+    _unit_agnostic = True
+    _info = {
+        "topographic__elevation": {
+            "dtype": "float",
+            "intent": "inout",
+            "optional": False,
+            "units": "m",
+            "mapping": "node",
+            "doc": "land and ocean bottom elevation, positive up",
+        },
+        "bedrock_surface__elevation": {
+            "dtype": "float",
+            "intent": "inout",
+            "optional": True,
+            "units": "m",
+            "mapping": "node",
+            "doc": "New bedrock elevation following subsidence",
+        },
+        "sea_level__elevation": {
+            "dtype": "float",
+            "intent": "inout",
+            "optional": False,
+            "units": "m",
+            "mapping": "grid",
+            "doc": "Sea level elevation",
+        },
+        "sediment_deposit__thickness": {
+            "dtype": "float",
+            "intent": "in",
+            "optional": False,
+            "units": "m",
+            "mapping": "node",
+            "doc": "Thickness of deposited or eroded sediment",
+        },
+    }
+
+    def __init__(self, grid, time_step=100.0, components=None, track=None):
+        self._components = () if components is None else tuple(components)
+        track = [] if track else track
+
+        super().__init__(grid)
+
+        self._time = 0.0
+        self._time_step = time_step
+
+        self.grid.at_layer_grid = EventLayers(1)
+        self.grid.at_layer_grid.add(
+            1.0, age=0.0, sea_level=0.0, x_of_shore=0, x_of_shelf_edge=0
+        )
+
+        if "bedrock_surface__elevation" not in self.grid.at_node:
+            self.grid.add_field(
+                "bedrock_surface__elevation",
+                self.grid.at_node["topographic__elevation"] - 100,
+                at="node",
+            )
+        initial_sediment_thickness = (
+            self.grid.at_node["topographic__elevation"]
+            - self.grid.at_node["bedrock_surface__elevation"]
+        )
+
+        self.add_layer(initial_sediment_thickness[self.grid.node_at_cell])
+
+    @property
+    def time(self):
+        return self._time
+
+    def update(self, dt=None):
+        dt = self._time_step if dt is None else dt
+
+        for component in self._components:
+            component.run_one_step(dt=dt)
+
+        self.add_layer(
+            self.grid.at_node["sediment_deposit__thickness"][self.grid.node_at_cell]
+        )
+
+        self._time += dt
+
+    def layer_properties(self):
+        dz = self.grid.at_node["sediment_deposit__thickness"]
+        water_depth = (
+            self.grid.at_grid["sea_level__elevation"]
+            - self.grid.at_node["topographic__elevation"]
+        )
+
+        properties = {
+            "age": self.time,
+            "water_depth": water_depth[self.grid.node_at_cell],
+            "t0": dz[self.grid.node_at_cell].clip(0.0),
+        }
+
+        try:
+            percent_sand = self.grid.at_node["delta_sediment_sand__volume_fraction"]
+        except KeyError:
+            pass
+        else:
+            properties["percent_sand"] = percent_sand[self.grid.node_at_cell]
+
+        return properties
+
+    def layer_reducers(self):
+        reducers = {
+            "age": np.max,
+            "water_depth": np.mean,
+            "t0": np.sum,
+        }
+        if "percent_sand" in self.grid.event_layers.tracking:
+            reducers["percent_sand"] = np.mean
+        # porosity = np.mean
+        return reducers
+
+    def add_layer(self, dz_at_cell):
+        self.grid.event_layers.add(dz_at_cell, **self.layer_properties())
+        self.grid.at_layer_grid.add(
+            1.0,
+            age=self.time,
+            sea_level=self.grid.at_grid["sea_level__elevation"],
+            x_of_shore=self.grid.at_grid["x_of_shore"],
+            x_of_shelf_edge=self.grid.at_grid["x_of_shelf_edge"],
+        )
+
+        try:
+            self._n_archived_layers
+        except AttributeError:
+            self._n_archived_layers = 0
+
+        if (
+            self.grid.event_layers.number_of_layers - self._n_archived_layers
+        ) % 20 == 0:
+            self.grid.event_layers.reduce(
+                self._n_archived_layers,
+                self._n_archived_layers + 10,
+                **self.layer_reducers(),
+            )
+            self._n_archived_layers += 1

--- a/sequence/submarine.py
+++ b/sequence/submarine.py
@@ -95,7 +95,8 @@ class SubmarineDiffuser(LinearDiffuser):
         grid.at_grid["sediment_load"] = self._load
 
         grid.add_zeros("kd", at="node")
-        grid.add_zeros("sediment_deposit__thickness", at="node")
+        if "sediment_deposit__thickness" not in grid.at_node:
+            grid.add_zeros("sediment_deposit__thickness", at="node")
 
         self._time = 0.0
 


### PR DESCRIPTION
This pull request adds a new class, *Sequence*, that allows users to build _sequence_ models within Python.

With this new class, users are able to chain together process components (available through `sequence.processes`) to create new *sequence* models that can be run through Python. In doing so, users are then able to run the model and dynamically change parameters as the model runs.

I've also create a new plotting function, `plot_grid`, that a user can run from python (rather than having to save the model to a *netCDF* file and run ``sequence plot`` from the command line) to see the current state of a *Sequence* model. 

The following code snippet shows how a user could create a new *Sequence* model, run it for 300k years, plot some output, double the sediment input to the model, run it for another 300k years and again plot output,

```python
>>> seq = Sequence(
...     grid,
...     time_step=100.0,
...     components=[
...         sea_level,
...         submarine_diffusion,
...         fluvial,
...         flexure,
...         shoreline,
...     ],
... )
>>> for _ in range(3000):
...         seq.update(dt=100.0)
>>> plot_grid(seq.grid)
>>> submarine_diffusion.sediment_load *= 2.0
>>> for _ in range(3000):
...         seq.update(dt=100.0)
>>> plot_grid(seq.grid)
```