### PR TITLE
Test notebooks

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -23,7 +23,7 @@ jobs:
           - uses: conda-incubator/setup-miniconda@v2
             with:
               auto-update-conda: true
-              python-version: 3.10
+              python-version: "3.10"
               channels: conda-forge
               channel-priority: true
 

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,0 +1,38 @@
+name: Test notebooks
+
+on: [push, pull_request]
+
+
+jobs:
+    build:
+        # We want to run on external PRs, but not on our own internal PRs as they'll be run
+        # by the push to the branch. Without this if check, checks are duplicated since
+        # internal PRs match both the push and pull_request events.
+        if:
+          github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+          github.repository
+    
+        runs-on: ubuntu-latest
+        
+        defaults:
+          run:
+            shell: bash -l {0}
+
+        steps:
+          - uses: actions/checkout@v2
+          - uses: conda-incubator/setup-miniconda@v2
+            with:
+              auto-update-conda: true
+              python-version: 3.10
+              channels: conda-forge
+              channel-priority: true
+
+          - name: Show conda installation info
+            run: conda info
+    
+          - name: Install dependencies
+            run: |
+              pip install -e ".[notebook,dev]"
+
+          - name: Test notebooks
+            run: pytest --nbmake notebooks/*ipynb            

--- a/news/52.misc
+++ b/news/52.misc
@@ -1,0 +1,3 @@
+Added a GitHub Actions workflow that tests the *sequence* notebooks. The
+notebooks are simply executed to ensure they run, not to validate any output.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
   "black",
   "flake8",
   "isort",
-  "nbcheck",
+  "nbmake",
   "pre-commit",
   "pytest",
   "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
   "black",
   "flake8",
   "isort",
+  "nbcheck",
   "pre-commit",
   "pytest",
   "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ doc = [
   "sphinxcontrib_github_alt",
   "pygments>=2.4",
 ]
+notebook = [
+  "notebook",
+]
 
 [project.scripts]
 sequence = "sequence.cli:sequence"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ doc = [
 ]
 notebook = [
   "notebook",
+  "tqdm",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This pull request adds continuous integration tests for the notebooks by adding a new GitHub Actions workflow, *notebooks.yml*. The notebooks are simply executed to ensure they run, not to validate any output. The notebooks are run using the *nbmake* plugin for *pytest*.