### PR TITLE
Change project name to sequence-model

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Test command line
         run: |
+          sequence --version
           mkdir example
           sequence --cd=example setup --set clock.stop=60000
           sequence --cd=example --silent run

--- a/README.rst
+++ b/README.rst
@@ -58,11 +58,11 @@ Stable Release
 *Sequence*, and its dependencies, can be installed either with *pip*
 or *conda*. Using *pip*::
 
-    $ pip install sequence
+    $ pip install sequence-model
 
 Using *conda*::
 
-    $ conda install sequence -c conda-forge
+    $ conda install sequence-model -c conda-forge
 
 From Source
 ```````````
@@ -72,6 +72,77 @@ After downloading the *Sequence* source code, run the following from
 install *Sequence* into the current environment::
 
   $ pip install -e .
+
+
+Usage
+-----
+
+*Sequence* is both a command-line program and a Python package that provides an
+application programming interface.
+
+The command-line program, *sequence*, provides several sub-commands for setting
+up *sequence* input files, running *sequence*, and plotting output (you can use
+the ``--help`` option to get help for the available subcommands). The four
+subcommands are the following:
+
+* `generate`: Generate example input files.
+* `setup`: Setup a folder of input files for a simulation.
+* `run`: Run a simulation.
+* `plot`: Plot a sequence output file.
+
+Example
+```````
+
+The following commands create an example set of input files, runs *sesquence*,
+and then plots the output.
+
+.. code:: bash
+
+  $ mkdir example && cd example
+  $ sequence setup
+  $ sequence run
+  $ sequence plot
+
+.. image:: https://github.com/sequence-dev/sequence/raw/develop/docs/_static/sequence.png
+
+The above can also be run through Python,
+
+.. code:: python
+
+  >>> from sequence import Sequence, SequenceModelGrid
+  >>> grid = SequenceModelGrid(100, spacing=1000.0)
+  >>> grid.at_node["topographic__elevation"] = -0.001 * grid.x_of_node + 20.0
+  
+  >>> sequence = Sequence()
+  >>> sequence.run()
+  >>> sequence.plot()
+
+The ``Sequence`` class provides functionality not available to the command-line
+program. For example, you are able to run a simulation through time while dynamically
+changing parameters.
+
+  >>> from sequence import Sequence, SequenceModelGrid  
+  >>> grid = SequenceModelGrid(100, spacing=1000.0)
+  >>> grid.at_node["topographic__elevation"] = -0.001 * grid.x_of_node + 20.0
+  
+  >>> process = default_process_queue()
+  >>> sequence = Sequence(
+  ...   grid,
+  ...   components=[
+  ...     process["sea_level"],
+  ...     process["compaction"],
+  ...     process["submarine_diffusion"],
+  ...     process["fluvial"],
+  ...     process["flexure"],
+  ...     process["shoreline"],
+  ...   ]
+  ... )  
+  
+  >>> sequence.run(until=300000.0, dt=100.0)
+  >>> sequence.submarine_diffusion.sediment_load *= 2.0
+  >>> sequence.run(until=600000.0, dt=100.0)
+  >>> sequence.plot()
+
 
 Input Files
 -----------
@@ -350,3 +421,4 @@ not be obvious,
 * *layer_start*: the first layer to plot
 * *layer_stop*: the last layer to plot (a value of -1 means stop at the last layer)
 * *n_layers*: the number of layers to plot.
+


### PR DESCRIPTION
This pull request changes the project name for *sequence* to *sequence-model*. The change was needed because the name *sequence* was already taken on *PyPI*.