### PR TITLE
Fix error recording x_of_shore, x_of_shelf_edge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,6 @@ jobs:
           sequence --cd=example --silent run
           sequence --cd=data/marmara --silent run
 
-      - name: Coveralls
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
-        uses: AndreMiras/coveralls-python-action@v20201129
+      # - name: Coveralls
+      #   if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
+      #   uses: AndreMiras/coveralls-python-action@v20201129

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,6 @@ jobs:
           sequence --cd=example --silent run
           sequence --cd=data/marmara --silent run
 
-      # - name: Coveralls
-      #   if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
-      #   uses: AndreMiras/coveralls-python-action@v20201129
+      - name: Coveralls
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
+        uses: AndreMiras/coveralls-python-action@v20201129

--- a/news/57.bugfix
+++ b/news/57.bugfix
@@ -1,0 +1,3 @@
+Fixed a bug where x_of_shore and x_of_shelf_edge were being incorrectly
+recorded (but correctly calculated).
+

--- a/sequence/sequence.py
+++ b/sequence/sequence.py
@@ -55,9 +55,6 @@ class Sequence(Component):
         self._time_step = time_step
 
         self.grid.at_layer_grid = EventLayers(1)
-        self.grid.at_layer_grid.add(
-            1.0, age=0.0, sea_level=0.0, x_of_shore=0.0, x_of_shelf_edge=0.0
-        )
 
         if "bedrock_surface__elevation" not in self.grid.at_node:
             self.grid.add_field(

--- a/sequence/sequence.py
+++ b/sequence/sequence.py
@@ -56,7 +56,7 @@ class Sequence(Component):
 
         self.grid.at_layer_grid = EventLayers(1)
         self.grid.at_layer_grid.add(
-            1.0, age=0.0, sea_level=0.0, x_of_shore=0, x_of_shelf_edge=0
+            1.0, age=0.0, sea_level=0.0, x_of_shore=0.0, x_of_shelf_edge=0.0
         )
 
         if "bedrock_surface__elevation" not in self.grid.at_node:
@@ -154,8 +154,14 @@ class Sequence(Component):
         return reducers
 
     def add_layer(self, dz_at_cell):
-        x_of_shore = self.grid.at_grid.get("x_of_shore", -1)
-        x_of_shelf_edge = self.grid.at_grid.get("x_of_shelf_edge", -1)
+        try:
+            x_of_shore = self.grid.at_grid["x_of_shore"]
+        except KeyError:
+            x_of_shore = np.nan
+        try:
+            x_of_shelf_edge = self.grid.at_grid["x_of_shelf_edge"]
+        except KeyError:
+            x_of_shelf_edge = np.nan
 
         self.grid.event_layers.add(dz_at_cell, **self.layer_properties())
         self.grid.at_layer_grid.add(


### PR DESCRIPTION
This pull request fixes a bug where both *x_of_shore* and *x_of_shelf_edge* were being incorrectly recored even though they were correctly calculated.