### PR TITLE
Add notebooks page to the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,10 +11,10 @@ formats:
 python:
   version: 3.8
   install:
-    - requirements: requirements-docs.txt
-    - requirements: requirements.txt
+    # - requirements: requirements-docs.txt
+    # - requirements: requirements.txt
     - method: pip
-      path: .
+      path: .[doc]
   system_packages: false
 
 build:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
-Changelog for Sequence
-======================
+Release Notes
+=============
 
 .. towncrier release notes start
 

--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,35 @@
-sequence: Sequence-stratigraphic modeling with Python
-=====================================================
+.. image:: https://raw.githubusercontent.com/sequence-dev/sequence/develop/docs/_static/sequence-logo-text-lowercase.png
+  :target: https://sequence.readthedocs.io/en/develop/?badge=develop
+  :alt: Sequence
+  :align: center
+  
+.. raw:: html
+
+  <h2 align="center">Sequence-stratigraphic modeling with Python</h2>
+
+-----------
 
 .. image:: https://github.com/sequence-dev/sequence/workflows/Build/Test%20CI/badge.svg
 
+
 .. image:: https://github.com/sequence-dev/sequence/workflows/Flake8/badge.svg
+
 
 .. image:: https://github.com/sequence-dev/sequence/workflows/Black/badge.svg
 
+
 .. image:: https://github.com/sequence-dev/sequence/workflows/Documentation/badge.svg
+
 
 .. image:: https://readthedocs.org/projects/sequence/badge/?version=develop
   :target: https://sequence.readthedocs.io/en/develop/?badge=develop
   :alt: Documentation Status
 
+-----------
+
+`Read the documentation on ReadTheDocs! <https://sequence.readthedocs.io/en/develop/>`_
+
+-----------
 
 About
 -----

--- a/README.rst
+++ b/README.rst
@@ -27,10 +27,6 @@
 
 -----------
 
-`Read the documentation on ReadTheDocs! <https://sequence.readthedocs.io/en/develop/>`_
-
------------
-
 About
 -----
 
@@ -40,6 +36,12 @@ Sequence represents time-averaged fluvial and marine sediment transport
 via differential equations. The modular code includes components to deal
 with sea level changes, sediment compaction, local or flexural isostasy,
 and tectonic subsidence and uplift.
+
+-----------
+
+`Read the documentation on ReadTheDocs! <https://sequence.readthedocs.io/en/develop/>`_
+
+-----------
 
 Requirements
 ------------

--- a/docs/_templates/links.html
+++ b/docs/_templates/links.html
@@ -1,7 +1,0 @@
-<h3>Useful Links</h3>
-<ul>
-  <li><a href="https://github.com/conda-forge/sequence-feedstock/">sequence @ conda-forge</a></li>
-  <li><a href="https://github.com/sequence-dev/sequence/">sequence @ GitHub</a></li>
-  <li><a href="https://github.com/sequence-dev/sequence/issues">Issue Tracker</a></li>
-</ul>
-

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -1,4 +1,0 @@
-<h3>About sequence</h3>
-<p>
-  Sequence-stratigraphic modeling with Python.
-</p>

--- a/docs/_templates/sidebaroutro.html
+++ b/docs/_templates/sidebaroutro.html
@@ -1,0 +1,3 @@
+<a href="https://csdms.colorado.edu">
+  <img src="_static/powered-by-logo-header.png" alt="Powered by CSDMS"/>
+</a>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,35 +18,8 @@
 # absolute, like shown here.
 #
 import os
-import sys
-
-from unittest.mock import MagicMock
 
 import sequence
-
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return MagicMock()
-
-
-MOCK_MODULES = [
-    "click",
-    "landlab",
-    "landlab.bmi.bmi_bridge",
-    "landlab.components",
-    "landlab.components.flexure",
-    "landlab.core",
-    "landlab.core.model_component",
-    "landlab.plot",
-    "netCDF4",
-    "numpy",
-    "scipy",
-    "yaml",
-]
-
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 
 if os.environ.get("READTHEDOCS", ""):
@@ -109,7 +82,7 @@ release = sequence.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -136,6 +109,18 @@ html_theme = "alabaster"
 # documentation.
 #
 # html_theme_options = {}
+html_theme_options = {
+    "description": "Sequence-stratigraphic modeling with Python.",
+    "logo": "sequence-logo-text-lowercase.png",
+    "logo_name": False,
+    "github_user": "sequence-dev",
+    "github_repo": "sequence",
+    "extra_nav_links": {
+        "sequence @ GitHub": "https://github.com/sequence-dev/sequence/",
+        "Contact Us": "https://github.com/sequence-dev/sequence/issues",
+    },
+}
+
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -203,21 +188,6 @@ napoleon_google_docstring = False
 napoleon_include_init_with_doc = True
 napoleon_include_special_with_doc = True
 
-# The name of an image file (relative to this directory) to place at the top
-# of the sidebar.
-html_logo = "_static/powered-by-logo-header.png"
-
 html_sidebars = {
-    "index": [
-        "sidebarintro.html",
-        "links.html",
-        "sourcelink.html",
-        "searchbox.html",
-    ],
-    "**": [
-        "sidebarintro.html",
-        "links.html",
-        "sourcelink.html",
-        "searchbox.html",
-    ],
+    "**": ["about.html", "searchbox.html", "navigation.html", "sidebaroutro.html"]
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ Getting Started
 ---------------
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
 
    readme
    notebooks

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ Getting Started
    :maxdepth: 3
 
    readme
+   notebooks
 
 ..   usage
 ..   installation

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -1,0 +1,1 @@
+.. include:: ../notebooks/README.rst

--- a/news/58.docs
+++ b/news/58.docs
@@ -1,0 +1,3 @@
+Updated the *sequence* documentation to include a page for
+`example notebooks <https://sequence.readthedocs.io/en/develop/notebooks.html>`_.
+

--- a/notebooks/README.rst
+++ b/notebooks/README.rst
@@ -1,0 +1,23 @@
+Example Notebooks
+=================
+
+This page is provides an index to the *Sequence* Jupyter Notebooks. 
+
+**Useful links**
+
+* `Sequence documentation <https://sequence.readthedocs.io/>`_
+* `Sequence source code <https://github.com/sequence-dev/sequence>`_
+* `Landlab documentation <https://landlab.readthedocs.io/>`_
+* `Landlab source code <https://github.com/landlab/landlab>`_
+* `Landlab user guide <https://landlab.readthedocs.io/en/latest/user_guide/>`_
+
+Introduction to Sequence
+------------------------
+
+In this introduction to *Sequence*, you will learn how to build and run a *Sequence* model from process components
+through Python.
+
+* `View notebook <https://github.com/sequence-dev/sequence/blob/develop/notebooks/example.ipynb>`_
+* `Launch notebook on CSDMS JupyterHub <https://lab.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fsequence-dev%2Fsequence&urlpath=tree%2Fsequence%2Fnotebooks%2Fexample.ipynb&branch=develop>`_
+
+

--- a/sequence/submarine.py
+++ b/sequence/submarine.py
@@ -53,6 +53,7 @@ class SubmarineDiffuser(LinearDiffuser):
         **kwds
     ):
         """Diffuse the ocean bottom.
+
         Parameters
         ----------
         grid: RasterModelGrid


### PR DESCRIPTION
This pull request has some minor updates to the docs: updating the sidebar and adding a page for the example notebooks.