### PR TITLE
Add tests for combinations of components

### DIFF
--- a/tests/test_sequence_model.py
+++ b/tests/test_sequence_model.py
@@ -1,9 +1,24 @@
 import os
 import shutil
+from itertools import chain, combinations, permutations
 
+import pytest
 from landlab.core import load_params
 
 from sequence.sequence_model import SequenceModel
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+ALL_PROCESSES = [
+    "sea_level",
+    "subsidence",
+    "compaction",
+    "submarine_diffusion",
+    "flexure",
+]
 
 
 # @pytest.mark.skip("test fails with a core dump from numpy")
@@ -15,17 +30,69 @@ def test_marmara(tmpdir, datadir):
         grid = SequenceModel.load_grid(params["grid"], bathymetry=params["bathymetry"])
         processes = SequenceModel.load_processes(
             grid,
-            processes=params.get(
-                "processes",
-                [
-                    "sea_level",
-                    "subsidence",
-                    "compaction",
-                    "submarine_diffusion",
-                    "fluvial",
-                    "flexure",
-                ],
-            ),
+            processes=params.get("processes", ALL_PROCESSES),
+            context=params,
+        )
+        model = SequenceModel(
+            grid, clock=params["clock"], processes=processes, output=params["output"]
+        )
+        model.run()
+
+        assert os.path.isfile("marmara.nc")
+
+
+@pytest.mark.parametrize("processes", permutations(ALL_PROCESSES))
+def test_component_ordering(tmpdir, datadir, processes):
+    with tmpdir.as_cwd():
+        for fname in datadir.iterdir():
+            shutil.copy(str(datadir / fname), ".")
+        with open("marmara.toml", "rb") as fp:
+            params = tomllib.load(fp)["sequence"]
+        grid = SequenceModel.load_grid(params["grid"], bathymetry=params["bathymetry"])
+        processes = SequenceModel.load_processes(
+            grid,
+            processes=processes,
+            context=params,
+        )
+        model = SequenceModel(
+            grid, clock=params["clock"], processes=processes, output=params["output"]
+        )
+        model.run()
+
+        assert os.path.isfile("marmara.nc")
+
+
+@pytest.mark.parametrize(
+    "processes",
+    chain(
+        combinations(ALL_PROCESSES, 0),
+        combinations(ALL_PROCESSES, 1),
+        combinations(ALL_PROCESSES, 2),
+        combinations(ALL_PROCESSES, 3),
+        combinations(ALL_PROCESSES, 4),
+    ),
+    ids=[
+        "-".join(combo)
+        for combo in chain(
+            combinations(ALL_PROCESSES, 0),
+            combinations(ALL_PROCESSES, 1),
+            combinations(ALL_PROCESSES, 2),
+            combinations(ALL_PROCESSES, 3),
+            combinations(ALL_PROCESSES, 4),
+        )
+    ],
+)
+def test_component_combos(tmpdir, datadir, processes):
+
+    with tmpdir.as_cwd():
+        for fname in datadir.iterdir():
+            shutil.copy(str(datadir / fname), ".")
+        with open("marmara.toml", "rb") as fp:
+            params = tomllib.load(fp)["sequence"]
+        grid = SequenceModel.load_grid(params["grid"], bathymetry=params["bathymetry"])
+        processes = SequenceModel.load_processes(
+            grid,
+            processes=processes,
             context=params,
         )
         model = SequenceModel(


### PR DESCRIPTION
This pull request adds tests for running *Sequence* with different combinations of components and component ordering. At this point, these tests are just smoke tests that check to see that *Sequence* ran without error and generated an output file.

I've also fixed an error found through these tests that caused a *Landlab* *FieldError* because of a missing *bedrock_surface__increment_of_elevation* field in the fluvial component.