### PR TITLE
Fix updating of the topographic elevations

### DIFF
--- a/news/67.bugfix
+++ b/news/67.bugfix
@@ -1,0 +1,3 @@
+
+Fixed a bug where the topographic elevations were not being updated correctly after the
+components were time stepped.

--- a/news/67.feature
+++ b/news/67.feature
@@ -1,0 +1,4 @@
+
+Added a :meth:`~sequence.SequenceModelGrid.get_profile` method to :class:`~sequence.SequenceModelGrid` that is a convenience
+function to return a field just along the middle row of nodes (i.e. along the
+profile).

--- a/news/67.feature.1
+++ b/news/67.feature.1
@@ -1,5 +1,6 @@
 
-Changed the subsidence components to only update the current amount of
-subsidence but to not update update secondary fields like the topographic
+Changed all components to only update the current amount of subsidence and
+deposited sediment but not to update secondary fields like the topographic
 elevation. This removes the dependence of these secondary fields on
-component ordering.
+component ordering and ensures these secondary fields are updated once, and only
+once, with each time step.

--- a/news/67.feature.1
+++ b/news/67.feature.1
@@ -1,0 +1,5 @@
+
+Changed the subsidence components to only update the current amount of
+subsidence but to not update update secondary fields like the topographic
+elevation. This removes the dependence of these secondary fields on
+component ordering.

--- a/news/67.misc
+++ b/news/67.misc
@@ -1,0 +1,2 @@
+
+Added tests for the compaction, flexure, and subsidence components.

--- a/sequence/_grid.py
+++ b/sequence/_grid.py
@@ -4,6 +4,7 @@ import sys
 
 import numpy as np
 from landlab import RasterModelGrid
+from numpy.typing import NDArray
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -40,6 +41,21 @@ class SequenceModelGrid(RasterModelGrid):
 
         self.at_node["sediment_deposit__thickness"] = self.zeros(at="node")
         self.at_grid["sea_level__elevation"] = 0.0
+
+    def get_profile(self, name: str) -> NDArray:
+        """Return the values of a field along the grid's profile.
+
+        Parameters
+        ----------
+        name : str
+            The name of an at-node field.
+
+        Returns
+        -------
+        values : ndarray
+            The values of the field located at the middle row of nodes.
+        """
+        return self.at_node[name].reshape(self.shape)[1]
 
     @classmethod
     def from_toml(cls, filepath: os.PathLike[str]) -> "SequenceModelGrid":

--- a/sequence/cli.py
+++ b/sequence/cli.py
@@ -232,7 +232,7 @@ def run(ctx: Any, with_citations: bool, dry_run: bool) -> None:
 
     times, names = _find_config_files(".")
     if not silent:
-        out(f"config_files = [{', '.join(repr(name) for name in names)}]")
+        out(f"[INFO] config_files: {', '.join(repr(name) for name in names)}")
     params = TimeVaryingConfig.from_files(names, times=times)
 
     model_params = params.as_dict()
@@ -250,20 +250,16 @@ def run(ctx: Any, with_citations: bool, dry_run: bool) -> None:
     )
 
     if verbose or not silent:
-        out("enabled = [")
         for name in model.components:
-            out(f"  {name!r},")
-        out("]")
-        out("disabled = [")
+            out(f"[INFO] ✅ enabled: {name}")
         for name in set(SequenceModel.ALL_PROCESSES) - set(model.components):
-            out(f"  {name!r},")
-        out("]")
+            out(f"[INFO] ❌ disabled {name}")
 
     if not silent and verbose:
         out(params.dump())
 
     if not silent and len(processes) == 0:
-        out("⚠️  ALL PROCESSES HAVE BEEN DISABLED! ⚠️")
+        out("[WARN] ⚠️  ALL PROCESSES HAVE BEEN DISABLED! ⚠️")
 
     if not silent and with_citations:
         from landlab.core.model_component import registry

--- a/sequence/cli.py
+++ b/sequence/cli.py
@@ -231,6 +231,10 @@ def run(ctx: Any, with_citations: bool, dry_run: bool) -> None:
     run_dir = pathlib.Path.cwd()
 
     times, names = _find_config_files(".")
+    if len(times) == 0:
+        err("[ERROR] unable to find a configuration file.")
+        raise click.Abort()
+
     if not silent:
         out(f"[INFO] config_files: {', '.join(repr(name) for name in names)}")
     params = TimeVaryingConfig.from_files(names, times=times)

--- a/sequence/sequence.py
+++ b/sequence/sequence.py
@@ -90,7 +90,14 @@ class Sequence(Component):
             - self.grid.at_node["bedrock_surface__elevation"]
         )
 
-        self.add_layer(initial_sediment_thickness[self.grid.node_at_cell])
+        if (initial_sediment_thickness[self.grid.node_at_cell] > 0.0).any():
+            self.add_layer(initial_sediment_thickness[self.grid.node_at_cell])
+
+        self.grid.at_node["topographic__elevation"][self.grid.node_at_cell] = (
+            self.grid.at_node["bedrock_surface__elevation"][self.grid.node_at_cell]
+            + self.grid.event_layers.thickness
+        )
+        self.grid.at_node["sediment_deposit__thickness"].fill(0.0)
 
     @property
     def time(self) -> float:
@@ -116,6 +123,11 @@ class Sequence(Component):
         self.add_layer(
             self.grid.at_node["sediment_deposit__thickness"][self.grid.node_at_cell]
         )
+        self.grid.at_node["topographic__elevation"][self.grid.node_at_cell] = (
+            self.grid.at_node["bedrock_surface__elevation"][self.grid.node_at_cell]
+            + self.grid.event_layers.thickness
+        )
+        self.grid.at_node["sediment_deposit__thickness"].fill(0.0)
 
     def run(
         self,
@@ -213,6 +225,10 @@ class Sequence(Component):
             x_of_shelf_edge = self.grid.at_grid["x_of_shelf_edge"]
         except KeyError:
             x_of_shelf_edge = np.nan
+
+        self.grid.at_node["topographic__elevation"][
+            self.grid.node_at_cell
+        ] += dz_at_cell
 
         self.grid.event_layers.add(dz_at_cell, **self.layer_properties())
         self.grid.at_layer_grid.add(

--- a/sequence/subsidence.py
+++ b/sequence/subsidence.py
@@ -62,10 +62,6 @@ class SubsidenceTimeSeries(Component):
 
         self._dz_dt = self._calc_subsidence_rate()
 
-        # self.grid.at_node["bedrock_surface__rate_of_subsidence"].reshape(
-        #     self.grid.shape
-        # )[:] += self._dz_dt
-
         self._time = 0.0
 
     @property

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1,0 +1,65 @@
+from numpy.testing import assert_array_almost_equal
+from pytest import approx
+
+from sequence import Sequence, SequenceModelGrid
+from sequence.processes import Compact
+
+
+def test_layers_compact():
+    grid = SequenceModelGrid(5)
+    grid.add_zeros("bedrock_surface__elevation", at="node")
+    grid.add_zeros("topographic__elevation", at="node")
+
+    compaction = Compact(
+        grid,
+        c=5e-08,
+        porosity_max=0.5,
+        porosity_min=0.01,
+        rho_grain=2650.0,
+        rho_void=1000.0,
+    )
+    sequence = Sequence(grid, time_step=100.0, components=[compaction])
+    assert grid.event_layers.number_of_layers == 0
+    for _ in range(n_layers := 15):
+        sequence.add_layer(100.0)
+    assert grid.event_layers.number_of_layers == 15
+    assert grid.at_node["topographic__elevation"][grid.node_at_cell] == approx(
+        n_layers * 100.0
+    )
+
+    sequence.run(progress_bar=False)
+
+    assert (grid.event_layers["porosity"][: n_layers - 1, :] < 0.5).all()
+    assert grid.event_layers["porosity"][n_layers - 1, :] == approx(0.5)
+
+    assert (grid.event_layers.dz[: n_layers - 1, :] < 100.0).all()
+    assert grid.event_layers.dz[n_layers - 1, :] == approx(100.0)
+
+
+def test_layers_compact_only_once():
+    grid = SequenceModelGrid(5)
+    grid.add_zeros("bedrock_surface__elevation", at="node")
+    grid.add_zeros("topographic__elevation", at="node")
+
+    compaction = Compact(
+        grid,
+        c=5e-08,
+        porosity_max=0.5,
+        porosity_min=0.01,
+        rho_grain=2650.0,
+        rho_void=1000.0,
+    )
+    sequence = Sequence(grid, time_step=100.0, components=[compaction])
+    assert grid.event_layers.number_of_layers == 0
+    for _ in range(15):
+        sequence.add_layer(100.0)
+
+    sequence.run(progress_bar=False)
+    assert sequence.time == approx(100.0)
+
+    thickness_of_layers = grid.event_layers.thickness.copy()
+
+    sequence.run(until=4000.0, progress_bar=False)
+    assert sequence.time == approx(4000.0)
+
+    assert_array_almost_equal(grid.event_layers.thickness, thickness_of_layers)

--- a/tests/test_flexure.py
+++ b/tests/test_flexure.py
@@ -68,12 +68,7 @@ def test_flexure():
     flexure = SedimentFlexure(grid)
     flexure.run_one_step()
 
-    assert (
-        grid.at_node["lithosphere_surface__increment_of_elevation"].reshape(grid.shape)[
-            1, :
-        ]
-        > 0.0
-    ).all()
+    assert (grid.get_profile("lithosphere_surface__increment_of_elevation") > 0.0).all()
     assert (grid.at_node["topographic__elevation"] == initial_elevation).all()
 
 

--- a/tests/test_flexure.py
+++ b/tests/test_flexure.py
@@ -1,15 +1,15 @@
+import numpy as np
 import pytest
-from landlab import RasterModelGrid
+from numpy.testing import assert_array_almost_equal
 
+from sequence import SequenceModelGrid
 from sequence.sediment_flexure import SedimentFlexure
 
 
 @pytest.fixture()
 def grid():
-    grid = RasterModelGrid((3, 4))
-    grid.add_empty("sediment_deposit__thickness", at="node")
+    grid = SequenceModelGrid(4, spacing=1.0)
     grid.add_empty("topographic__elevation", at="node")
-    grid.add_empty("bedrock_surface__elevation", at="node")
     return grid
 
 
@@ -61,18 +61,96 @@ def test_update_bulk_density(grid, prop):
 
 
 def test_flexure():
-    grid = RasterModelGrid((3, 4))
-    grid.add_empty("sediment_deposit__thickness", at="node")
-    grid.add_zeros("topographic__elevation", at="node")
-    grid.add_zeros("bedrock_surface__elevation", at="node")
+    grid = SequenceModelGrid(100)
+    initial_elevation = grid.add_zeros("topographic__elevation", at="node").copy()
 
     grid.at_node["sediment_deposit__thickness"][:] = 1.0
     flexure = SedimentFlexure(grid)
     flexure.run_one_step()
 
     assert (
-        grid.at_node["topographic__elevation"].reshape(grid.shape)[1, 1:-1] < 0.0
+        grid.at_node["lithosphere_surface__increment_of_elevation"].reshape(grid.shape)[
+            1, :
+        ]
+        > 0.0
     ).all()
-    assert (
-        grid.at_node["bedrock_surface__elevation"].reshape(grid.shape)[1, 1:-1] < 0.0
-    ).all()
+    assert (grid.at_node["topographic__elevation"] == initial_elevation).all()
+
+
+def test_all_dry():
+    z = np.asarray([4.0, 3.0, 2.0, 1.0, 0.0])
+    sediment_density = 1.0
+    water_density = 0.5
+    dz = np.full_like(z, 2.0)
+
+    loading = SedimentFlexure._calc_loading(dz, z, sediment_density, water_density)
+
+    assert_array_almost_equal(loading, dz * sediment_density)
+
+
+def test_all_wet():
+    z = np.asarray([-2.0, -3.0, -4.0, -5.0, -6.0])
+    sediment_density = 1.0
+    water_density = 0.5
+    dz = np.full_like(z, 2.0)
+
+    loading = SedimentFlexure._calc_loading(dz, z, sediment_density, water_density)
+
+    assert_array_almost_equal(loading, dz * water_density)
+
+
+def test_loading_wet_or_dry():
+    z = np.asarray([2.0, 1.0, 0.0, -1.0, -2.0])
+    sediment_density = 2000.0
+    water_density = 1000.0
+    dz = np.full_like(z, 0.5)
+
+    loading = SedimentFlexure._calc_loading(dz, z, sediment_density, water_density)
+
+    assert_array_almost_equal(
+        loading, [0.5 * 2000.0, 0.5 * 2000, 0.5 * 2000, 0.5 * 1000, 0.5 * 1000]
+    )
+
+
+def test_loading_mixed():
+    z = np.asarray([1.0, 0.0, -1.0, -2.0, -3.0])
+    sediment_density = 1.0
+    water_density = 0.5
+    dz = np.full_like(z, 2.0)
+
+    loading = SedimentFlexure._calc_loading(dz, z, sediment_density, water_density)
+
+    assert_array_almost_equal(loading, [2.0, 2.0, 1.0 + 0.5, 1.0, 1.0])
+
+
+def test_dry_erosion():
+    z = np.asarray([4.0, 3.0, 2.0, 1.0, 0.0])
+    sediment_density = 1.0
+    water_density = 0.5
+    dz = np.asarray([-1.0, -1.0, 1.0, 1.0, 1.0])
+
+    loading = SedimentFlexure._calc_loading(dz, z, sediment_density, water_density)
+
+    assert_array_almost_equal(loading, dz * sediment_density)
+
+
+def test_wet_erosion():
+    z = np.asarray([0.0, -1.0, -2.0, -3.0, -4.0])
+    sediment_density = 1.0
+    water_density = 0.5
+    dz = np.asarray([-1.0, -1.0, 1.0, 1.0, 1.0])
+
+    loading = SedimentFlexure._calc_loading(dz, z, sediment_density, water_density)
+
+    assert_array_almost_equal(loading, dz * (sediment_density - water_density))
+
+
+def test_mixed_erosion():
+    z = np.asarray([3.0, 2.0, 1.0, 0.0, -1.0])
+    sediment_density = 1.0
+    water_density = 0.5
+    dz = np.asarray([-2.0, -2.0, -2.0, 2.0, 2.0])
+
+    loading = SedimentFlexure._calc_loading(dz, z, sediment_density, water_density)
+
+    assert_array_almost_equal(loading, [-2.0, -2.0, -1.0 - 0.5, 2.0, 1.0 + 0.5])

--- a/tests/test_subsidence.py
+++ b/tests/test_subsidence.py
@@ -1,14 +1,12 @@
 import pytest
-from landlab import RasterModelGrid
 from numpy.testing import assert_array_equal
 
+from sequence import SequenceModelGrid
 from sequence.subsidence import SubsidenceTimeSeries
 
 
 def test_bad_filepath(tmpdir):
-    grid = RasterModelGrid((3, 5))
-    grid.add_full("bedrock_surface__elevation", 0.0, at="node")
-    grid.add_full("topographic__elevation", 0.0, at="node")
+    grid = SequenceModelGrid(5)
 
     with pytest.raises(TypeError):
         SubsidenceTimeSeries(grid)
@@ -18,85 +16,108 @@ def test_bad_filepath(tmpdir):
             SubsidenceTimeSeries(grid, filepath="missing-file.csv")
 
 
-def test_constant_subsidence(tmpdir):
-    grid = RasterModelGrid((3, 5))
-    grid.add_full("bedrock_surface__elevation", 0.0, at="node")
-    grid.add_full("topographic__elevation", 0.0, at="node")
+def test_time_step(tmpdir):
+    grid = SequenceModelGrid(5, spacing=1.0)
 
     with tmpdir.as_cwd():
         with open("subsidence.csv", "w") as fp:
             fp.write("0.0,1.0\n5.0,1.0")
         subsidence = SubsidenceTimeSeries(grid, filepath="subsidence.csv")
-        assert_array_equal(grid.at_node["bedrock_surface__increment_of_elevation"], 1.0)
+        assert_array_equal(subsidence.subsidence_rate, 1.0)
+        assert_array_equal(grid.at_node["bedrock_surface__increment_of_elevation"], 0.0)
 
         subsidence.run_one_step(dt=1.0)
-        assert_array_equal(grid.at_node["bedrock_surface__elevation"], 1.0)
+        assert_array_equal(subsidence.subsidence_rate, 1.0)
+        assert_array_equal(
+            grid.get_profile("bedrock_surface__increment_of_elevation"), 1.0
+        )
+
+        grid.at_node["bedrock_surface__increment_of_elevation"][:] = 0.0
+        subsidence.run_one_step(dt=2.0)
+        assert_array_equal(
+            grid.get_profile("bedrock_surface__increment_of_elevation"), 2.0
+        )
+
+
+def test_constant_subsidence(tmpdir):
+    grid = SequenceModelGrid(5, spacing=1.0)
+
+    with tmpdir.as_cwd():
+        with open("subsidence.csv", "w") as fp:
+            fp.write("0.0,1.0\n5.0,1.0")
+        subsidence = SubsidenceTimeSeries(grid, filepath="subsidence.csv")
+        assert_array_equal(grid.at_node["bedrock_surface__increment_of_elevation"], 0.0)
 
         subsidence.run_one_step(dt=1.0)
-        assert_array_equal(grid.at_node["bedrock_surface__elevation"], 2.0)
+        assert_array_equal(
+            grid.get_profile("bedrock_surface__increment_of_elevation"), 1.0
+        )
+
+        grid.at_node["bedrock_surface__increment_of_elevation"][:] = 0.0
+        subsidence.run_one_step(dt=1.0)
+        assert_array_equal(
+            grid.get_profile("bedrock_surface__increment_of_elevation"), 1.0
+        )
 
 
 def test_linear_subsidence(tmpdir):
-    grid = RasterModelGrid((3, 5))
-    grid.add_full("bedrock_surface__elevation", 0.0, at="node")
-    grid.add_full("topographic__elevation", 0.0, at="node")
+    grid = SequenceModelGrid(5, spacing=1.0)
 
     with tmpdir.as_cwd():
         with open("subsidence.csv", "w") as fp:
             fp.write("0.0,0.0\n4.0,40.0")
         subsidence = SubsidenceTimeSeries(grid, filepath="subsidence.csv")
+        assert_array_equal(subsidence.subsidence_rate, [0.0, 10.0, 20.0, 30.0, 40.0])
+        assert_array_equal(grid.at_node["bedrock_surface__increment_of_elevation"], 0.0)
+
+        grid.at_node["bedrock_surface__increment_of_elevation"][:] = 0.0
+        subsidence.run_one_step(dt=1.0)
         assert_array_equal(
-            grid.at_node["bedrock_surface__increment_of_elevation"].reshape((3, 5)),
-            [
-                [0.0, 10.0, 20.0, 30.0, 40.0],
-                [0.0, 10.0, 20.0, 30.0, 40.0],
-                [0.0, 10.0, 20.0, 30.0, 40.0],
-            ],
+            grid.get_profile("bedrock_surface__increment_of_elevation"),
+            [0.0, 10.0, 20.0, 30.0, 40.0],
         )
+
+
+def test_add_to_existing_subsidence(tmpdir):
+    grid = SequenceModelGrid(5, spacing=1.0)
+    grid.add_ones("bedrock_surface__increment_of_elevation", at="node")
+
+    with tmpdir.as_cwd():
+        with open("subsidence.csv", "w") as fp:
+            fp.write("0.0,0.0\n4.0,40.0")
+        subsidence = SubsidenceTimeSeries(grid, filepath="subsidence.csv")
+        assert_array_equal(subsidence.subsidence_rate, [0.0, 10.0, 20.0, 30.0, 40.0])
+        assert_array_equal(grid.at_node["bedrock_surface__increment_of_elevation"], 1.0)
 
         subsidence.run_one_step(dt=1.0)
         assert_array_equal(
-            grid.at_node["bedrock_surface__elevation"].reshape((3, 5)),
-            [
-                [0.0, 10.0, 20.0, 30.0, 40.0],
-                [0.0, 10.0, 20.0, 30.0, 40.0],
-                [0.0, 10.0, 20.0, 30.0, 40.0],
-            ],
-        )
-
-        subsidence.run_one_step(dt=1.0)
-        assert_array_equal(
-            grid.at_node["bedrock_surface__elevation"].reshape((3, 5)),
-            [
-                [0.0, 20.0, 40.0, 60.0, 80.0],
-                [0.0, 20.0, 40.0, 60.0, 80.0],
-                [0.0, 20.0, 40.0, 60.0, 80.0],
-            ],
+            grid.get_profile("bedrock_surface__increment_of_elevation"),
+            [1.0, 11.0, 21.0, 31.0, 41.0],
         )
 
 
 def test_set_subsidence_file(tmpdir):
-    grid = RasterModelGrid((3, 5))
-    grid.add_full("bedrock_surface__elevation", 0.0, at="node")
-    grid.add_full("topographic__elevation", 0.0, at="node")
+    grid = SequenceModelGrid(5, spacing=1.0)
 
     with tmpdir.as_cwd():
         with open("subsidence-0.csv", "w") as fp:
             fp.write("0.0,10.0\n4.0,10.0")
-        subsidence = SubsidenceTimeSeries(grid, filepath="subsidence-0.csv")
-        assert_array_equal(
-            grid.at_node["bedrock_surface__increment_of_elevation"], 10.0
-        )
-
-        subsidence.run_one_step(dt=1.0)
-        assert_array_equal(grid.at_node["bedrock_surface__elevation"], 10.0)
-
         with open("subsidence-1.csv", "w") as fp:
             fp.write("0.0,-100.0\n4.0,-100.0")
-        subsidence.filepath = "subsidence-1.csv"
-        assert_array_equal(
-            grid.at_node["bedrock_surface__increment_of_elevation"], -100.0
-        )
+
+        subsidence = SubsidenceTimeSeries(grid, filepath="subsidence-0.csv")
+        assert_array_equal(subsidence.subsidence_rate, 10.0)
 
         subsidence.run_one_step(dt=1.0)
-        assert_array_equal(grid.at_node["bedrock_surface__elevation"], -90.0)
+        assert_array_equal(
+            grid.get_profile("bedrock_surface__increment_of_elevation"), 10.0
+        )
+
+        grid.at_node["bedrock_surface__increment_of_elevation"][:] = 0.0
+        subsidence.filepath = "subsidence-1.csv"
+        assert_array_equal(subsidence.subsidence_rate, -100.0)
+
+        subsidence.run_one_step(dt=1.0)
+        assert_array_equal(
+            grid.get_profile("bedrock_surface__increment_of_elevation"), -100
+        )


### PR DESCRIPTION
This pull request does a few things but it is mainly intended to fix a problem where the topographic elevations were not being updated correctly after running the components each time step. To fix this, I've changed all of the components to no longer update derived fields such as elevation. Instead, components only add to the current amount of subsidence or sediment deposited. At the end of each time step the sequence model uses these fields to calculate derived fields such as the topography and the elevation of bedrock. The subsidence rates and deposition rates are then reset before running the next time step. This also has the advantage of removing any dependency on the ordering of components.