### PR TITLE
Improve logging messages

### DIFF
--- a/news/68.feature
+++ b/news/68.feature
@@ -1,0 +1,5 @@
+
+Improved the logging of *Sequence*. *Sequence* now logs time spent running
+each component, and the options available for the plot command. From the
+command line, users are able to control the detail of the log messages through
+the ``--verbose`` and ``--silent`` options.

--- a/sequence/logging.py
+++ b/sequence/logging.py
@@ -16,7 +16,7 @@ LOG_LEVEL_STYLES: dict[str, dict[str, Any]] = {
     "CRITICAL": {"bold": True, "fg": "bright_red"},
 }
 
-MULTILINE_FORMAT: dict[str, Any] = {"dim": True, "italic": True}
+MULTILINE_STYLES: dict[str, Any] = {"dim": True, "italic": True}
 
 
 class LoggingHandler(logging.Handler):
@@ -40,7 +40,7 @@ class LoggingHandler(logging.Handler):
 
         if len(lines) > 1:
             for line in lines[1:]:
-                print(click.style(f"+ {line}", **MULTILINE_FORMAT), file=sys.stderr)
+                print(click.style(f"+ {line}", **MULTILINE_STYLES), file=sys.stderr)
 
 
 @contextlib.contextmanager

--- a/sequence/logging.py
+++ b/sequence/logging.py
@@ -1,0 +1,55 @@
+"""Logger used for printing Sequence log messages."""
+import contextlib
+import logging
+import sys
+from typing import Any, Generator
+
+import click
+
+logger = logging.getLogger("sequence")
+
+LOG_LEVEL_STYLES: dict[str, dict[str, Any]] = {
+    "DEBUG": {"bold": True, "dim": True},
+    "INFO": {"bold": True, "dim": True},
+    "WARNING": {"bold": True, "fg": "bright_yellow"},
+    "ERROR": {"bold": True, "fg": "red"},
+    "CRITICAL": {"bold": True, "fg": "bright_red"},
+}
+
+MULTILINE_FORMAT: dict[str, Any] = {"dim": True, "italic": True}
+
+
+class LoggingHandler(logging.Handler):
+    """Print Sequence log messages."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Print a log message.
+
+        Parameters
+        ----------
+        record : LogRecord
+            The log to print.
+        """
+        level_msg = click.style(
+            f"[{record.levelname}]", **LOG_LEVEL_STYLES[record.levelname]
+        )
+        lines = record.getMessage().splitlines()
+        if len(lines) == 0:
+            lines = [""]
+        print(f"{level_msg} {lines[0]}", file=sys.stderr)
+
+        if len(lines) > 1:
+            for line in lines[1:]:
+                print(click.style(f"+ {line}", **MULTILINE_FORMAT), file=sys.stderr)
+
+
+@contextlib.contextmanager
+def logging_handler() -> Generator[None, None, None]:
+    """Change, temporarily, the current logger."""
+    handler = LoggingHandler()
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    try:
+        yield
+    finally:
+        logger.removeHandler(handler)

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -28,7 +28,7 @@ def plot_layers(
     layer_start: int = 0,
     layer_stop: int = -1,
     n_layers: int = 5,
-    title: Optional[str] = None,
+    title: str = "",
     x_label: str = "Distance (m)",
     y_label: str = "Elevation (m)",
     legend_location: str = "lower left",


### PR DESCRIPTION
This pull request improves the logging of the *Sequence* model. I've added  a logging handler, using the Python *logging* module,  to print custom log messages of various levels. From the command line interface users can control the level through the `--verbose` and `--silent` options.

The *SequenceModel* now keeps track of the total amount of time spent running each component, which is logged at the end of the run. Running the plot command now prints the various plot options—previously the user was left to guess or dig through the code to find out what those options were.