### PR TITLE
Include not yet released changes in the Release Notes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 Release Notes
 =============
 
+.. towncrier-draft-entries:: Not yet released
+
 .. towncrier release notes start
 
 0.5.1 (2022-06-30)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,11 @@
 # absolute, like shown here.
 #
 import os
+import pathlib
 
 import sequence
+
+docs_dir = os.path.dirname(__file__)
 
 if os.environ.get("READTHEDOCS", ""):
     # RTD doesn't use the repo's Makefile to build docs.
@@ -47,6 +50,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx_inline_tabs",
+    "sphinxcontrib.towncrier",
     # "IPython.sphinxext.ipython_console_highlighting",
     # "sphinxcontrib_github_alt",
 ]
@@ -190,3 +194,9 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "landlab": ("https://landlab.readthedocs.io/en/master/", None),
 }
+
+# -- Options for towncrier_draft extension --------------------------------------------
+
+towncrier_draft_autoversion_mode = "draft"  # or: 'sphinx-release', 'sphinx-version'
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = pathlib.Path(docs_dir).parent

--- a/news/69.docs
+++ b/news/69.docs
@@ -1,0 +1,3 @@
+
+Updated the documentation to now include an unreleased section of the release
+notes that includes changes since the latest release.

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,7 @@ def test_cli(session: nox.Session) -> None:
 def lint(session: nox.Session) -> None:
     """Look for lint."""
     session.install("pre-commit")
-    session.run("pre-commit", "run", "--all-files")
+    session.run("pre-commit", "run", "--all-files", "--verbose")
 
 
 @nox.session
@@ -67,6 +67,19 @@ def towncrier(session: nox.Session) -> None:
     """Check that there is a news fragment."""
     session.install("towncrier")
     session.run("towncrier", "check", "--compare-with", "origin/develop")
+
+
+@nox.session(name="build-requirements", reuse_venv=True)
+def build_requirements(session: nox.Session) -> None:
+    """Create requirements files from pyproject.toml."""
+    session.install("tomli")
+
+    with open("requirements.txt", "w") as fp:
+        session.run("python", "requirements.py", stdout=fp)
+
+    for extra in ["dev", "doc", "notebook"]:
+        with open(f"requirements-{extra}.txt", "w") as fp:
+            session.run("python", "requirements.py", extra, stdout=fp)
 
 
 @nox.session(name="build-docs", reuse_venv=True)
@@ -84,8 +97,8 @@ def build_docs(session: nox.Session) -> None:
             "-force",
             "--no-toc",
             "--module-first",
-            "--templatedir",
-            "docs/_templates",
+            # "--templatedir",
+            # "docs/_templates",
             "-o",
             "docs/api",
             "sequence",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
 ]
 doc = [
   "sphinx",
+  "sphinxcontrib.towncrier",
   "pygments>=2.4",
   "sphinx-inline-tabs",
   "furo",


### PR DESCRIPTION
This pull request adds a _Not Yet Released_ section to the _Release Notes_ page of the docs that shows the changes since the latest release.