### PR TITLE
Fix building docs on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,13 +9,17 @@ formats:
   - htmlzip
 
 python:
-  version: 3.8
   install:
-    # - requirements: requirements-docs.txt
-    # - requirements: requirements.txt
+    - requirements: requirements-doc.txt
+    - requirements: requirements.txt
     - method: pip
-      path: .[doc]
+      path: .
   system_packages: false
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+  jobs:
+    pre_build:
+      - sphinx-apidoc -e -force --no-toc --module-first -o docs/api sequence

--- a/news/70.misc
+++ b/news/70.misc
@@ -1,0 +1,2 @@
+
+Fixed an issue with building the docs on *readthedocs*.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,15 @@
+# Requirements extracted from pyproject.toml
+# [project.optional-dependencies.dev]
+black
+coverage
+flake8
+isort
+nbmake
+nox
+pre-commit
+pytest
+pytest-cov
+pytest-datadir
+pytest-runner
+pytest-xdist
+towncrier

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,0 +1,7 @@
+# Requirements extracted from pyproject.toml
+# [project.optional-dependencies.doc]
+sphinx
+sphinxcontrib.towncrier
+pygments>=2.4
+sphinx-inline-tabs
+furo

--- a/requirements-notebook.txt
+++ b/requirements-notebook.txt
@@ -1,0 +1,4 @@
+# Requirements extracted from pyproject.toml
+# [project.optional-dependencies.notebook]
+notebook
+tqdm


### PR DESCRIPTION
This pull request fixes building the docs on _readthedocs_. I've changed the _readthedocs_ config file to use the new build section, build with Python 3.9, and run *sphinx-apidoc* before the build step.