### PR TITLE
Fix updating the flexure component

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,11 +22,14 @@ repos:
     types_or: [python, pyi, jupyter]
     additional_dependencies: [".[jupyter]"]
 
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/pycqa/flake8
+  rev: 4.0.1
   hooks:
-  - id: flake8
-    # additional_dependencies: [flake8-bugbear]
+    - id: flake8
+      additional_dependencies:
+        - flake8-bugbear
+        - flake8-comprehensions
+        - flake8-simplify
 
 - repo: https://gitlab.com/iamlikeme/nbhooks
   rev: 1.0.0

--- a/news/71.feature
+++ b/news/71.feature
@@ -1,0 +1,4 @@
+
+Changed the :class:`~sequence.sediment_flexure.SedimentFlexure` component so
+that it is no longer dependent on the ordering of components. It has been
+simplified so that it now takes sediment loading as its only input field.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyyaml
 rich-click
 scipy
 tomlkit
+tqdm

--- a/sequence/cli.py
+++ b/sequence/cli.py
@@ -403,7 +403,7 @@ def plot(ctx: Any, set: str) -> None:
         logger.info(
             os.linesep.join(
                 [
-                    "Reading configuration\n",
+                    "Reading configuration",
                     toml.dumps(dict(sequence=dict(plot=config))),
                 ]
             )

--- a/sequence/cli.py
+++ b/sequence/cli.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pathlib
 import re
+from contextlib import suppress
 from io import StringIO
 from os import PathLike
 from typing import Any, Iterable, Iterator, Optional, Union
@@ -91,11 +92,13 @@ def _contents_of_input_file(infile: Union[str, PathLike[str]], set: str) -> str:
     contents = {
         "sequence.yaml": yaml.dump(params, default_flow_style=False),
         "sequence.toml": toml.dumps(
-            dict(
-                sequence=dict(
-                    _time=0.0, processes=SequenceModel.ALL_PROCESSES, **params
-                )
-            )
+            {
+                "sequence": {
+                    "_time": 0.0,
+                    "processes": SequenceModel.ALL_PROCESSES,
+                    **params,
+                }
+            }
         ),
         "bathymetry.csv": as_csv(
             [[0.0, 20.0], [100000.0, -80.0]], header="X [m], Elevation [m]"
@@ -122,7 +125,7 @@ def _contents_of_input_file(infile: Union[str, PathLike[str]], set: str) -> str:
     return contents[str(infile)]
 
 
-def _time_from_filename(name: Union[str, PathLike[str]]) -> Union[int, None]:
+def _time_from_filename(name: Union[str, PathLike[str]]) -> Optional[int]:
     """Parse a time stamp from a file name.
 
     Parameters
@@ -299,14 +302,11 @@ def run(ctx: Any, with_citations: bool, dry_run: bool) -> None:
             disable=True if silent else None,
         )
 
-        try:
-            with progressbar as bar:
-                while 1:
-                    model.run_one_step()
-                    model.set_params(params.update(1))
-                    bar.update(1)
-        except StopIteration:
-            pass
+        with suppress(StopIteration), progressbar as bar:
+            while 1:
+                model.run_one_step()
+                model.set_params(params.update(1))
+                bar.update(1)
 
         if verbose and not silent:
             total = sum(model.timer.values())
@@ -394,7 +394,7 @@ def plot(ctx: Any, set: str) -> None:
         config.update(
             TimeVaryingConfig.from_file(folder / "sequence.toml")
             .as_dict()
-            .get("plot", dict())
+            .get("plot", {})
         )
 
     config.update(**_load_params_from_strings(set))
@@ -404,7 +404,7 @@ def plot(ctx: Any, set: str) -> None:
             os.linesep.join(
                 [
                     "Reading configuration",
-                    toml.dumps(dict(sequence=dict(plot=config))),
+                    toml.dumps({"sequence": {"plot": config}}),
                 ]
             )
         )
@@ -471,7 +471,7 @@ def _walk_dict(indict: Union[dict, Any], prev: Optional[list] = None) -> Iterato
         for key, value in indict.items():
             if isinstance(value, dict):
                 yield from _walk_dict(value, [key] + prev)
-            elif isinstance(value, list) or isinstance(value, tuple):
+            elif isinstance(value, (list, tuple)):
                 yield prev + [key, value]
             else:
                 yield prev + [key, value]

--- a/sequence/input_reader.py
+++ b/sequence/input_reader.py
@@ -183,7 +183,7 @@ class TimeVaryingConfig:
             doc["_time"] = time
 
         if fmt == "toml":
-            return toml.dumps(dict(sequence=docs))
+            return toml.dumps({"sequence": docs})
         elif fmt == "yaml":
             return yaml.dump(docs, default_flow_style=False)
         else:
@@ -276,9 +276,9 @@ class TimeVaryingConfig:
             The configurations and their associated times.
         """
 
-        def _tomlkit_to_popo(d: dict) -> Any:
+        def _tomlkit_to_popo(d: Any) -> Any:
             try:
-                result = getattr(d, "value")
+                result = d.value
             except AttributeError:
                 result = d
 
@@ -446,7 +446,7 @@ def _walk_dict(
         for key, value in indict.items():
             if isinstance(value, dict):
                 yield from _walk_dict(value, prev_dicts + [key])
-            elif isinstance(value, list) or isinstance(value, tuple):
+            elif isinstance(value, (list, tuple)):
                 yield tuple(prev_dicts + [key]), value
             else:
                 yield tuple(prev_dicts + [key]), value

--- a/sequence/netcdf.py
+++ b/sequence/netcdf.py
@@ -204,7 +204,7 @@ def to_netcdf(
     at: Optional[Union[str, Sequence[str]]] = None,
     ids: Optional[Union[dict[str, Iterable[int]], int, Iterable[int], slice]] = None,
     names: Optional[
-        Union[dict[str, Union[Iterable[str], None]], str, Iterable[str]]
+        Union[dict[str, Optional[Iterable[str]]], str, Iterable[str]]
     ] = None,
     with_layers: bool = True,
 ) -> None:

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -253,7 +253,7 @@ def plot_file(filename: Union[str, PathLike], **kwds: Any) -> None:
     )
 
 
-def _get_layers_to_plot(start: int, stop: int, num: int = -1) -> Union[slice, None]:
+def _get_layers_to_plot(start: int, stop: int, num: int = -1) -> Optional[slice]:
     if num == 0:
         return None
     elif num < 0 or num > stop - start + 1:
@@ -292,8 +292,8 @@ def _outline_layer(
     x: NDArray,
     y_of_bottom_layer: NDArray,
     y_of_top_layer: NDArray,
-    bottom_limits: Optional[tuple[Union[float, None], Union[float, None]]] = None,
-    top_limits: Optional[tuple[Union[float, None], Union[float, None]]] = None,
+    bottom_limits: Optional[tuple[Optional[float], Optional[float]]] = None,
+    top_limits: Optional[tuple[Optional[float], Optional[float]]] = None,
 ) -> tuple[NDArray, NDArray]:
     if bottom_limits is None:
         bottom_limits = (None, None)

--- a/sequence/sediment_flexure.py
+++ b/sequence/sediment_flexure.py
@@ -9,7 +9,7 @@ from ._grid import SequenceModelGrid
 
 
 class SedimentFlexure(Flexure1D):
-    """*Landlab* component that deflects a `SequenceModelGrid` due sediment loading."""
+    """*Landlab* component that deflects a `SequenceModelGrid` due to sediment loading."""
 
     _name = "Sediment-loading flexure"
 
@@ -57,6 +57,22 @@ class SedimentFlexure(Flexure1D):
             "units": "m",
             "mapping": "node",
             "doc": "Total amount of subsidence",
+        },
+        "sediment__increment_of_thickness": {
+            "dtype": "float",
+            "intent": "in",
+            "optional": True,
+            "units": "m",
+            "mapping": "node",
+            "doc": "Thickness of new sediment",
+        },
+        "sediment__bulk_density": {
+            "dtype": "float",
+            "intent": "in",
+            "optional": True,
+            "units": "m",
+            "mapping": "node",
+            "doc": "Density of new sediment",
         },
     }
 

--- a/sequence/sediment_flexure.py
+++ b/sequence/sediment_flexure.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 import numpy as np
 import tomlkit as toml
 from landlab.components.flexure import Flexure1D
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import NDArray
 
 from ._grid import SequenceModelGrid
 
@@ -123,8 +123,10 @@ class SedimentFlexure(Flexure1D):
 
     @staticmethod
     def calc_bulk_density(
-        grain_density: ArrayLike, void_density: ArrayLike, porosity: ArrayLike
-    ) -> ArrayLike:
+        grain_density: NDArray[np.floating],
+        void_density: NDArray[np.floating],
+        porosity: NDArray[np.floating],
+    ) -> NDArray[np.floating]:
         """Calculate the bulk density of a material with a given porosity.
 
         Parameters

--- a/sequence/sediment_flexure.py
+++ b/sequence/sediment_flexure.py
@@ -1,11 +1,15 @@
 """Subside a `SequenceModelGrid` using flexure."""
+import logging
 from typing import Union
 
 import numpy as np
+import tomlkit as toml
 from landlab.components.flexure import Flexure1D
-from numpy.typing import NDArray
+from numpy.typing import ArrayLike, NDArray
 
 from ._grid import SequenceModelGrid
+
+logger = logging.getLogger("sequence")
 
 
 class SedimentFlexure(Flexure1D):
@@ -18,37 +22,13 @@ class SedimentFlexure(Flexure1D):
     _time_units = "y"
 
     _info = {
-        "sediment_deposit__thickness": {
+        "sediment__total_of_loading": {
             "dtype": "float",
             "intent": "in",
             "optional": True,
             "units": "m",
             "mapping": "node",
-            "doc": "Thickness of deposited or eroded sediment",
-        },
-        "sea_level__elevation": {
-            "dtype": "float",
-            "intent": "in",
-            "optional": True,
-            "units": "m",
-            "mapping": "grid",
-            "doc": "Elevation of sea level",
-        },
-        "topographic__elevation": {
-            "dtype": "float",
-            "intent": "in",
-            "optional": True,
-            "units": "m",
-            "mapping": "node",
-            "doc": "land and ocean bottom elevation, positive up",
-        },
-        "delta_sediment_sand__volume_fraction": {
-            "dtype": "float",
-            "intent": "in",
-            "optional": True,
-            "units": "-",
-            "mapping": "node",
-            "doc": "delta sand fraction",
+            "doc": "Total sediment loading",
         },
         "bedrock_surface__increment_of_elevation": {
             "dtype": "float",
@@ -57,22 +37,6 @@ class SedimentFlexure(Flexure1D):
             "units": "m",
             "mapping": "node",
             "doc": "Total amount of subsidence",
-        },
-        "sediment__increment_of_thickness": {
-            "dtype": "float",
-            "intent": "in",
-            "optional": True,
-            "units": "m",
-            "mapping": "node",
-            "doc": "Thickness of new sediment",
-        },
-        "sediment__bulk_density": {
-            "dtype": "float",
-            "intent": "in",
-            "optional": True,
-            "units": "m",
-            "mapping": "node",
-            "doc": "Density of new sediment",
         },
     }
 
@@ -84,7 +48,6 @@ class SedimentFlexure(Flexure1D):
         isostasytime: Union[float, None] = 7000.0,
         water_density: float = 1030.0,
         **kwds: dict,
-        # **sediments,
     ):
         """Subside elevations due to sediment loading.
 
@@ -105,10 +68,10 @@ class SedimentFlexure(Flexure1D):
         self._sand_density = SedimentFlexure.validate_density(sand_density)
         self._mud_density = SedimentFlexure.validate_density(mud_density)
 
-        self._rho_sand = self._calc_bulk_density(
+        self._rho_sand = self.calc_bulk_density(
             self.sand_density, self.water_density, 0.4
         )
-        self._rho_mud = self._calc_bulk_density(
+        self._rho_mud = self.calc_bulk_density(
             self.mud_density, self.water_density, 0.65
         )
 
@@ -121,28 +84,64 @@ class SedimentFlexure(Flexure1D):
         )
         self._dt = 1.0
 
+        if "sediment__total_of_loading" not in grid.at_node:
+            grid.add_zeros("sediment__total_of_loading", at="node")
+
         super().__init__(grid, rows=1, **kwds)
 
         if "lithosphere__increment_of_overlying_pressure" not in grid.at_node:
             grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
         if "lithosphere_surface__increment_of_elevation" not in grid.at_node:
             grid.add_empty("lithosphere_surface__increment_of_elevation", at="node")
-        if "sea_level__elevation" not in grid.at_grid:
-            grid.at_grid["sea_level__elevation"] = 0.0
-        if "delta_sediment_sand__volume_fraction" not in grid.at_node:
-            grid.add_ones("delta_sediment_sand__volume_fraction", at="node")
         if "bedrock_surface__increment_of_elevation" not in grid.at_node:
-            grid.add_empty("bedrock_surface__increment_of_elevation", at="node")
+            grid.add_zeros("bedrock_surface__increment_of_elevation", at="node")
 
-        self.subs_pool = np.zeros_like(
+        self._subs_pool = np.zeros_like(
             self.grid.get_profile("lithosphere_surface__increment_of_elevation")
+        )
+        self._last_load = self.grid.get_profile("sediment__total_of_loading").copy()
+
+        logger.debug(
+            "Flexure parameters\n"
+            + toml.dumps(
+                {
+                    "sand_density": self._sand_density,
+                    "mud_density": self._mud_density,
+                    "water_density": self._water_density,
+                    "isostasy_time": 0.0
+                    if self.isostasy_time is None
+                    else self.isostasy_time,
+                    "alpha": self.alpha,
+                    "rigidity": self.rigidity,
+                    "gamma_mantle": self.gamma_mantle,
+                    "method": self.method,
+                    "eet": self.eet,
+                    "youngs": self.youngs,
+                }
+            )
         )
 
     @staticmethod
-    def _calc_bulk_density(
-        grain_density: float, water_density: float, porosity: float
-    ) -> float:
-        return grain_density * (1.0 - porosity) + water_density * porosity
+    def calc_bulk_density(
+        grain_density: ArrayLike, void_density: ArrayLike, porosity: ArrayLike
+    ) -> ArrayLike:
+        """Calculate the bulk density of a material with a given porosity.
+
+        Parameters
+        ----------
+        grain_density : float
+            Density of grains.
+        void_density : float
+            Density of material that fills the void space.
+        porosity : float
+            The porosity of the mixture.
+
+        Returns
+        -------
+        float
+            The bulk density of the material.
+        """
+        return grain_density * (1.0 - porosity) + void_density * porosity
 
     @staticmethod
     def validate_density(density: float) -> float:
@@ -204,7 +203,7 @@ class SedimentFlexure(Flexure1D):
     def sand_density(self, density: float) -> None:
         # porosity = 40%
         self._sand_density = SedimentFlexure.validate_density(density)
-        self._rho_sand = SedimentFlexure._calc_bulk_density(
+        self._rho_sand = SedimentFlexure.calc_bulk_density(
             self.sand_density, self.water_density, 0.4
         )
 
@@ -222,7 +221,7 @@ class SedimentFlexure(Flexure1D):
     def mud_density(self, density: float) -> None:
         # porosity = 65%
         self._mud_density = SedimentFlexure.validate_density(density)
-        self._rho_mud = SedimentFlexure._calc_bulk_density(
+        self._rho_mud = SedimentFlexure.calc_bulk_density(
             self.mud_density, self.water_density, 0.65
         )
 
@@ -239,10 +238,10 @@ class SedimentFlexure(Flexure1D):
     @water_density.setter
     def water_density(self, density: float) -> None:
         self._water_density = SedimentFlexure.validate_density(density)
-        self._rho_sand = SedimentFlexure._calc_bulk_density(
+        self._rho_sand = SedimentFlexure.calc_bulk_density(
             self.sand_density, self.water_density, 0.4
         )
-        self._rho_mud = SedimentFlexure._calc_bulk_density(
+        self._rho_mud = SedimentFlexure.calc_bulk_density(
             self.mud_density, self.water_density, 0.65
         )
 
@@ -250,6 +249,7 @@ class SedimentFlexure(Flexure1D):
     def _calc_loading(
         deposit_thickness: NDArray[np.floating],
         z: NDArray[np.floating],
+        sediment_porosity: float,
         sediment_density: Union[float, NDArray[np.floating]],
         water_density: float,
     ) -> NDArray[np.floating]:
@@ -262,6 +262,8 @@ class SedimentFlexure(Flexure1D):
         z : array-like
             The elevation of the profile before the new sediment has
             been added.
+        sediment_porosity : float
+            The porosity of the sediment.
         sediment_density : float
             The bulk density of the added sediment.
         water_density : float
@@ -276,17 +278,20 @@ class SedimentFlexure(Flexure1D):
 
         dry = (z >= 0.0) & (z_new >= 0.0)
         wet = (z <= 0.0) & (z_new <= 0.0)
+
+        void_density = np.zeros_like(z)
+        void_density[wet] = water_density
+
         mixed = ~dry & ~wet
-
-        density = np.full_like(z, sediment_density)
-        density[wet] -= water_density
-
         dry_fraction = np.abs(
             np.maximum(z_new[mixed], z[mixed]) / deposit_thickness[mixed]
         )
-        wet_fraction = 1.0 - dry_fraction
 
-        density[mixed] -= wet_fraction * water_density
+        void_density[mixed] = water_density * (1.0 - dry_fraction)
+
+        density = SedimentFlexure.calc_bulk_density(
+            sediment_density, void_density, sediment_porosity
+        )
 
         return density * deposit_thickness
 
@@ -347,26 +352,12 @@ class SedimentFlexure(Flexure1D):
         """Update the component by a single time step."""
         self.grid.get_profile("lithosphere_surface__increment_of_elevation").fill(0.0)
 
-        sea_level = self.grid.at_grid["sea_level__elevation"]
-        elevation = self.grid.get_profile("topographic__elevation")
-        deposit_thickness = self.grid.get_profile("sediment_deposit__thickness")
-        sand_fraction = self.grid.get_profile("delta_sediment_sand__volume_fraction")
-
-        sediment_density = self._calc_density(
-            sand_fraction, self.sand_bulk_density, self.mud_bulk_density
-        )
+        total_load = self.grid.get_profile("sediment__total_of_loading")
+        new_load = total_load - self._last_load
+        self._last_load[:] = total_load
 
         pressure = self.grid.get_profile("lithosphere__increment_of_overlying_pressure")
-        pressure[:] = (
-            self._calc_loading(
-                deposit_thickness,
-                elevation - sea_level,
-                sediment_density,
-                self.water_density,
-            )
-            * self.gravity
-            * self.grid.dx
-        )
+        pressure[:] = new_load * self.gravity * self.grid.dx
 
         Flexure1D.update(self)
 
@@ -374,14 +365,14 @@ class SedimentFlexure(Flexure1D):
             "lithosphere_surface__increment_of_elevation"
         )
         isostasy_fraction = self._calc_isostasy_fraction(self.isostasy_time, self._dt)
-        self.subs_pool[:] += isostatic_deflection
-        deflection = self.subs_pool[:] * isostasy_fraction
-        self.subs_pool[:] = self.subs_pool[:] - deflection
+        self._subs_pool[:] += isostatic_deflection
+        deflection_due_to_flexure = self._subs_pool[:] * isostasy_fraction
+        self._subs_pool[:] = self._subs_pool[:] - deflection_due_to_flexure
 
         total_deflection = self.grid.get_profile(
             "bedrock_surface__increment_of_elevation"
         )
-        total_deflection += deflection
+        total_deflection -= deflection_due_to_flexure
 
     def run_one_step(self, dt: float = 1.0) -> None:
         """Update the component by a time step.

--- a/sequence/sediment_flexure.py
+++ b/sequence/sediment_flexure.py
@@ -1,6 +1,6 @@
 """Subside a `SequenceModelGrid` using flexure."""
 import logging
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import tomlkit as toml
@@ -45,7 +45,7 @@ class SedimentFlexure(Flexure1D):
         grid: SequenceModelGrid,
         sand_density: float = 2650,
         mud_density: float = 2720.0,
-        isostasytime: Union[float, None] = 7000.0,
+        isostasytime: Optional[float] = 7000.0,
         water_density: float = 1030.0,
         **kwds: dict,
     ):
@@ -190,7 +190,7 @@ class SedimentFlexure(Flexure1D):
         return time
 
     @property
-    def isostasy_time(self) -> Union[float, None]:
+    def isostasy_time(self) -> Optional[float]:
         """Return the isostasy time."""
         return self._isostasy_time
 
@@ -244,6 +244,14 @@ class SedimentFlexure(Flexure1D):
         self._rho_mud = SedimentFlexure.calc_bulk_density(
             self.mud_density, self.water_density, 0.65
         )
+
+    @staticmethod
+    def calc_water_load(
+        z: NDArray[np.floating], water_density: float
+    ) -> NDArray[np.floating]:
+        """Calculate the water load."""
+        water_depth = np.clip(-z, a_min=0.0, a_max=None)
+        return water_density * water_depth
 
     @staticmethod
     def _calc_loading(
@@ -327,7 +335,7 @@ class SedimentFlexure(Flexure1D):
         return sand_fraction * sand_density + (1.0 - sand_fraction) * mud_density
 
     @staticmethod
-    def _calc_isostasy_fraction(isostasy_time: Union[float, None], dt: float) -> float:
+    def _calc_isostasy_fraction(isostasy_time: Optional[float], dt: float) -> float:
         """Calculate the fraction of isostatic subsidence.
 
         Parameters

--- a/sequence/sequence_model.py
+++ b/sequence/sequence_model.py
@@ -355,6 +355,21 @@ class SequenceModel:
 
     def _update_fields(self) -> None:
         """Update fields that depend on other fields."""
+        if "sediment__total_of_loading" in self.grid.at_node:
+            new_load = SedimentFlexure._calc_loading(
+                self.grid.get_profile("sediment_deposit__thickness"),
+                self.grid.get_profile("topographic__elevation")
+                - self.grid.at_grid["sea_level__elevation"],
+                0.5,
+                SedimentFlexure._calc_density(
+                    self.grid.get_profile("delta_sediment_sand__volume_fraction"),
+                    2650.0,
+                    2720.0,
+                ),
+                1030.0,
+            )
+            self.grid.get_profile("sediment__total_of_loading")[:] += new_load
+
         if "bedrock_surface__increment_of_elevation" in self.grid.at_node:
             self.grid.at_node["bedrock_surface__elevation"] += self.grid.at_node[
                 "bedrock_surface__increment_of_elevation"

--- a/sequence/subsidence.py
+++ b/sequence/subsidence.py
@@ -47,9 +47,6 @@ class SubsidenceTimeSeries(Component):
         if "bedrock_surface__increment_of_elevation" not in grid.at_node:
             grid.add_zeros("bedrock_surface__increment_of_elevation", at="node")
 
-        if "lithosphere_surface__increment_of_elevation" not in grid.at_node:
-            grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
-
         super().__init__(grid)
 
         self._filepath = filepath

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -28,9 +28,8 @@ def test_load_config_from_stream(datadir):
 
 
 def test_from_stream_without_format_keyword(datadir):
-    with open(datadir / "sequence.toml") as fp:
-        with pytest.raises(ValueError):
-            load_config(fp)
+    with open(datadir / "sequence.toml") as fp, pytest.raises(ValueError):
+        load_config(fp)
 
 
 @pytest.mark.parametrize("fmt", ("yaml", "toml"))
@@ -53,9 +52,8 @@ def test_bad_format(tmpdir, datadir):
 
 
 def test_missing_file(tmpdir):
-    with tmpdir.as_cwd():
-        with pytest.raises(OSError):
-            load_config("not-a-file.toml")
+    with tmpdir.as_cwd(), pytest.raises(OSError):
+        load_config("not-a-file.toml")
 
 
 @pytest.mark.parametrize("fmt", ("yaml", "toml"))

--- a/tests/test_subsidence.py
+++ b/tests/test_subsidence.py
@@ -11,9 +11,8 @@ def test_bad_filepath(tmpdir):
     with pytest.raises(TypeError):
         SubsidenceTimeSeries(grid)
 
-    with tmpdir.as_cwd():
-        with pytest.raises(OSError):
-            SubsidenceTimeSeries(grid, filepath="missing-file.csv")
+    with tmpdir.as_cwd(), pytest.raises(OSError):
+        SubsidenceTimeSeries(grid, filepath="missing-file.csv")
 
 
 def test_time_step(tmpdir):


### PR DESCRIPTION
In this pull request I've modified the flexure component so that it is not dependent on its ordering with other components. Previously, it had to come at the end of the component queue so that it could use the *sediment__deposit_thickness* field. Because this field is reset to zero every time step, if flexure was run too early in the queue, it would not see any load and so not result cause any deflection.

To fix this, I've changed flexure to accept a field of loads, which is calculated every time step by the *SequenceModel*.