### PR TITLE
Add extras rows to make Sequence quasi-2d

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -33,5 +33,5 @@ jobs:
           - name: Install dependencies
             run: pip install nox
 
-          - name: Build documentation
+          - name: Test notebooks
             run: nox -s test-notebooks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1,4 +1,4 @@
-# ``sequence``
+# Command-line interface
 
 The *Sequence* model can be run from the command line using the
 *sequence* program.

--- a/docs/reference/cli/input_files.md
+++ b/docs/reference/cli/input_files.md
@@ -58,11 +58,34 @@ spacing = 1000.0
 ```
 
 In this case we have a grid that represents a 1D profile that consists of
-500 columns (i.e. vertical stacks) of sediment (the *n_cols* parameter).
+100 columns (i.e. vertical stacks) of sediment (the *n_cols* parameter).
 
 The *spacing* parameter is the width of each of your sediment stacks in meters.
 Thus, the length of you domain is the product of the number of columns with
-the spacing (that is, for this example, 500 * 100 m or 50 km).
+the spacing (that is, for this example, 100 * 1000 m or 100 km).
+
+You can also run *Sequence* in a quasi-2d mode in which *Sequence* models parallel
+cross-shore profiles. Each profile will have its own sediment supply that is
+transported into the ocean and then can be diffused between profiles. To set up
+such a case, the grid section can, for example, be modified in the following way,
+
+```toml
+[sequence.grid]
+shape = [3, 100]
+spacing = [10000.0, 1000.0]
+```
+In this case *Sequence* will create three parallel profiles (with an along-shore
+width of 10000.0 m).
+
+:::{note}
+The following is equivalent to the 1D example above,
+
+```toml
+[sequence.grid]
+shape = [1, 100]
+spacing = [1.0, 1000.0]
+```
+:::
 
 (the-output-section)=
 

--- a/docs/tutorials/cli/sealevel.md
+++ b/docs/tutorials/cli/sealevel.md
@@ -27,7 +27,7 @@ we replace this section with the following,
 
 ```toml
 [sequence.sea_level]
-filepath = sealevel.csv
+filepath = "sealevel.csv"
 ```
 
 With this configuration, *Sequence* will read sea level values from this

--- a/news/78.feature
+++ b/news/78.feature
@@ -1,0 +1,3 @@
+
+Added a quasi-2d mode for *Sequence* that keeps track of multiple cross-shore
+rows.

--- a/sequence/_grid.py
+++ b/sequence/_grid.py
@@ -15,32 +15,76 @@ else:
 class SequenceModelGrid(RasterModelGrid):
     """Create a Landlab ModelGrid for use with Sequence."""
 
-    def __init__(self, n_cols: int, spacing: float = 100.0):
+    def __init__(
+        self, shape: int | tuple[int, int], spacing: float | tuple[float, float] = 100.0
+    ):
         """Create a *Landlab* :class:`~landlab.grid.base.ModelGrid` for use with *Sequence*.
 
         Parameters
         ----------
-        n_cols : int
-            The number of columns.
-        spacing : float, optional
-            The spacing between columns.
+        shape : int or tuple of int
+            The number of columns in the cross-shore direction or, if a ``tuple``,
+            ``(n_rows, n_cols)``  where rows are in the along-shore direction and
+            columns in the cross-shore direction.
+        spacing : float or tuple of float, optional
+            The spacing between columns or, if ``len(shape) == 2``,
+            ``(row_spacing, col_spacing)``.
 
         Examples
         --------
         >>> from sequence import SequenceModelGrid
-        >>> grid = SequenceModelGrid(500, spacing=10.0)
-        >>> grid.shape
-        (3, 500)
-        >>> grid.spacing
-        (1.0, 10.0)
+        >>> grid = SequenceModelGrid(5, spacing=10.0)
+        >>> grid.y_of_row
+        array([  0.,  1.,  2.])
+        >>> grid.x_of_column
+        array([ 0.,  10.,  20.,  30.,  40.])
+
+        >>> grid = SequenceModelGrid((3, 5), spacing=(10000.0, 10.0))
+        >>> grid.y_of_row
+        array([  0.,  10000.,  20000.,  30000., 40000.])
+        >>> grid.x_of_column
+        array([ 0.,  10.,  20.,  30.,  40.])
         """
-        super().__init__((3, n_cols), xy_spacing=(spacing, 1.0))
+        shape = np.atleast_1d(np.asarray(shape, dtype=int))
+        spacing = np.atleast_1d(np.asarray(spacing, dtype=float))
+
+        if (
+            (len(shape) == 1 and len(spacing) != 1) or (len(shape) != 1 and len(spacing) != len(shape))
+        ):
+            raise ValueError(
+                f"spacing dimension ({len(spacing)}) does not match shape"
+                f" dimension ({len(shape)})"
+            )
+
+        if len(shape) == 1:
+            n_rows, n_cols = 1, shape[0]
+        elif len(shape) == 2:
+            n_rows, n_cols = shape
+        else:
+            raise ValueError(f"invalid number of dimensions for grid ({len(shape)})")
+
+        if len(shape) == 1:
+            row_spacing, col_spacing = 1.0, spacing[0]
+        elif len(shape) == 2:
+            row_spacing, col_spacing = spacing
+
+        super().__init__((n_rows + 2, n_cols), xy_spacing=(col_spacing, row_spacing))
 
         self.status_at_node[self.nodes_at_top_edge] = self.BC_NODE_IS_CLOSED
         self.status_at_node[self.nodes_at_bottom_edge] = self.BC_NODE_IS_CLOSED
 
         self.at_node["sediment_deposit__thickness"] = self.zeros(at="node")
         self.at_grid["sea_level__elevation"] = 0.0
+
+        self.new_field_location("row", size=int(n_rows))
+
+    @property
+    def x_of_column(self) -> NDArray:
+        return self.x_of_node[self.nodes_at_top_edge]
+
+    @property
+    def y_of_row(self) -> NDArray:
+        return self.y_of_node[self.nodes_at_left_edge]
 
     def get_profile(self, name: str) -> NDArray:
         """Return the values of a field along the grid's profile.
@@ -55,7 +99,8 @@ class SequenceModelGrid(RasterModelGrid):
         values : ndarray
             The values of the field located at the middle row of nodes.
         """
-        return self.at_node[name].reshape(self.shape)[1]
+        return self.at_node[name].reshape(self.shape)[1:-1]
+        # return self.at_node[name].reshape(self.shape)[row]
 
     @classmethod
     def from_toml(cls, filepath: os.PathLike[str]) -> "SequenceModelGrid":
@@ -85,19 +130,36 @@ class SequenceModelGrid(RasterModelGrid):
         params : dict
             A dictionary that contains the parameters needed to
             create the grid.
+
+        Examples
+        --------
+        >>> from sequence import SequenceModelGrid
+        >>> params = {"shape": 5, "spacing": 10.0}
+        >>> grid = SequenceModelGrid.from_dict(params)
+        >>> grid.y_of_row
+        array([  0.,  1.,  2.])
+        >>> grid.x_of_column
+        array([ 0.,  10.,  20.,  30.,  40.])
+
+        >>> params = {"shape": (3, 5), "spacing": (10000.0, 10.0)}
+        >>> grid = SequenceModelGrid.from_dict(params)
+        >>> grid.y_of_row
+        array([  0.,  10000.,  20000.,  30000., 40000.])
+        >>> grid.x_of_column
+        array([ 0.,  10.,  20.,  30.,  40.])
         """
-        if "n_cols" in params:
-            n_cols = params["n_cols"]
-        elif "shape" in params:
-            n_cols = params["shape"][1]
+        if "shape" in params:
+            shape = params["shape"]
+        elif "n_cols" in params:
+            shape = params["n_cols"]
         else:
-            raise KeyError("n_cols")
+            raise KeyError("shape")
 
         if "spacing" in params:
             spacing = params["spacing"]
         elif "xy_spacing" in params:
-            spacing = np.broadcast_to(params["xy_spacing"], 2)[0]
+            spacing = np.atleast_1d(params["xy_spacing"])[::-1]
         else:
             raise KeyError("spacing")
 
-        return cls(n_cols, spacing=spacing)
+        return cls(shape, spacing=spacing)

--- a/sequence/_grid.py
+++ b/sequence/_grid.py
@@ -78,6 +78,7 @@ class SequenceModelGrid(RasterModelGrid):
         self.at_node["sediment_deposit__thickness"] = self.zeros(at="node")
         self.at_grid["sea_level__elevation"] = 0.0
 
+        # self.new_field_location("row", size=int(n_rows + 2))
         self.new_field_location("row", size=int(n_rows))
 
     @property
@@ -87,10 +88,13 @@ class SequenceModelGrid(RasterModelGrid):
 
     @property
     def number_of_rows(self) -> int:
-        return self.shape[0] - 2
+        """Number of rows of nodes."""
+        return self.shape[0]
+        # return self.shape[0] - 2
 
     @property
     def number_of_columns(self) -> int:
+        """Number of columns of nodes."""
         return self.shape[1]
 
     @property

--- a/sequence/_grid.py
+++ b/sequence/_grid.py
@@ -86,6 +86,14 @@ class SequenceModelGrid(RasterModelGrid):
         return self.x_of_node[self.nodes_at_top_edge]
 
     @property
+    def number_of_rows(self) -> int:
+        return self.shape[0] - 2
+
+    @property
+    def number_of_columns(self) -> int:
+        return self.shape[1]
+
+    @property
     def y_of_row(self) -> NDArray:
         """Y-coordinate for each row of the grid."""
         return self.y_of_node[self.nodes_at_left_edge]

--- a/sequence/_grid.py
+++ b/sequence/_grid.py
@@ -45,28 +45,30 @@ class SequenceModelGrid(RasterModelGrid):
         >>> grid.x_of_column
         array([ 0.,  10.,  20.,  30.,  40.])
         """
-        shape = np.atleast_1d(np.asarray(shape, dtype=int))
-        spacing = np.atleast_1d(np.asarray(spacing, dtype=float))
+        row_col_shape: list[int] = np.atleast_1d(np.asarray(shape, dtype=int))
+        row_col_spacing: list[float] = np.atleast_1d(np.asarray(spacing, dtype=float))
 
-        if (
-            (len(shape) == 1 and len(spacing) != 1) or (len(shape) != 1 and len(spacing) != len(shape))
+        if (len(row_col_shape) == 1 and len(row_col_spacing) != 1) or (
+            len(row_col_shape) != 1 and len(row_col_spacing) != len(row_col_shape)
         ):
             raise ValueError(
-                f"spacing dimension ({len(spacing)}) does not match shape"
-                f" dimension ({len(shape)})"
+                f"spacing dimension ({len(row_col_spacing)}) does not match shape"
+                f" dimension ({len(row_col_shape)})"
             )
 
-        if len(shape) == 1:
-            n_rows, n_cols = 1, shape[0]
-        elif len(shape) == 2:
-            n_rows, n_cols = shape
+        if len(row_col_shape) == 1:
+            n_rows, n_cols = 1, row_col_shape[0]
+        elif len(row_col_shape) == 2:
+            n_rows, n_cols = row_col_shape
         else:
-            raise ValueError(f"invalid number of dimensions for grid ({len(shape)})")
+            raise ValueError(
+                f"invalid number of dimensions for grid ({len(row_col_shape)})"
+            )
 
-        if len(shape) == 1:
-            row_spacing, col_spacing = 1.0, spacing[0]
-        elif len(shape) == 2:
-            row_spacing, col_spacing = spacing
+        if len(row_col_shape) == 1:
+            row_spacing, col_spacing = 1.0, row_col_spacing[0]
+        elif len(row_col_shape) == 2:
+            row_spacing, col_spacing = row_col_spacing
 
         super().__init__((n_rows + 2, n_cols), xy_spacing=(col_spacing, row_spacing))
 
@@ -80,10 +82,12 @@ class SequenceModelGrid(RasterModelGrid):
 
     @property
     def x_of_column(self) -> NDArray:
+        """X-coordinate for each column of the grid."""
         return self.x_of_node[self.nodes_at_top_edge]
 
     @property
     def y_of_row(self) -> NDArray:
+        """Y-coordinate for each row of the grid."""
         return self.y_of_node[self.nodes_at_left_edge]
 
     def get_profile(self, name: str) -> NDArray:

--- a/sequence/errors.py
+++ b/sequence/errors.py
@@ -29,15 +29,33 @@ class ShelfEdgeError(SequenceError):
         return self._msg
 
 
-class MissingRequiredVariable(SequenceError):
+class OutputValidationError(SequenceError):
+    """Raise this exception if there is something wrong with an output file."""
+
+    pass
+
+
+class InvalidRowError(OutputValidationError):
+    """Raise this exception if a required variable is missing from an output file."""
+
+    def __init__(self, row: int, n_rows: int):
+        self._row = row
+        self._n_rows = n_rows
+
+    def __str__(self) -> str:
+        """Return error message that includes the requested row."""
+        return f"row {self._row!r} is out of bounds for output file with {self._n_rows} rows"
+
+
+class MissingRequiredVariable(OutputValidationError):
     """Raise this exception if a required variable is missing from an output file."""
 
     def __init__(self, name: str):
         self._name = name
 
-    def __str_(self) -> str:
+    def __str__(self) -> str:
         """Return error message that includes the name of the missing variable."""
-        return f"{self._name!r}"
+        return f"requireed variable ({self._name!r}) is missing from output file"
 
 
 class ParameterMismatchError(SequenceError):

--- a/sequence/fluvial.py
+++ b/sequence/fluvial.py
@@ -122,10 +122,6 @@ class Fluvial(Component):
         dt : float
             The time step to update the component by.
         """
-
-        # return
-
-        # Upstream boundary conditions  */
         mud_vol = self.sediment_load * (1.0 - self.sand_frac) / self.sand_frac
         sand_vol = self.sediment_load
         qs = (

--- a/sequence/output_writer.py
+++ b/sequence/output_writer.py
@@ -54,7 +54,7 @@ class OutputWriter(Component):
         if rows is not None:
             self._rows = np.asarray(rows) - 1
         else:
-            self._rows = np.arange(grid.shape[0] - 2) + 1
+            self._rows = np.arange(grid.shape[0] - 2)
 
         self._time = 0.0
         self._step_count = 0

--- a/sequence/output_writer.py
+++ b/sequence/output_writer.py
@@ -4,6 +4,7 @@ import os
 from os import PathLike
 from typing import Iterable, Optional, Union
 
+import numpy as np
 from landlab import Component
 
 from ._grid import SequenceModelGrid
@@ -51,9 +52,9 @@ class OutputWriter(Component):
         self.filepath = filepath
 
         if rows is not None:
-            self._nodes = grid.nodes[(rows,)].flatten()
+            self._rows = np.asarray(rows) - 1
         else:
-            self._nodes = None
+            self._rows = np.arange(grid.shape[0] - 2) + 1
 
         self._time = 0.0
         self._step_count = 0
@@ -74,7 +75,10 @@ class OutputWriter(Component):
                 mode="a",
                 time=self._time,
                 names={"node": self.fields},
-                ids={"node": self._nodes},
+                ids={
+                    "row": self._rows,
+                    "column": np.arange(self.grid.shape[1] - 2),
+                },
             )
         self._time += dt
         self._step_count += 1

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -187,7 +187,7 @@ def plot_grid(grid: SequenceModelGrid, row: Optional[int] = None, **kwds: Any) -
     :func:`plot_file` : Plot a `SequenceModelGrid`'s layers from a file.
     """
     if row is None:
-        row = grid.number_of_rows // 2
+        row = (grid.number_of_rows - 2) // 2
 
     elevation_at_layer = (
         grid.get_profile("bedrock_surface__elevation")[row, 1:-1] + grid.at_layer.z
@@ -201,8 +201,10 @@ def plot_grid(grid: SequenceModelGrid, row: Optional[int] = None, **kwds: Any) -
     time_at_layer_grid = grid.at_layer_grid["age"].flatten()
     time_at_layer = grid.at_layer["age"]
 
-    x_of_shore = interp1d(time_at_layer_grid, x_of_shore[:, row])(time_at_layer[:, 0])
-    x_of_shelf_edge = interp1d(time_at_layer_grid, x_of_shelf_edge[:, row])(
+    x_of_shore = interp1d(time_at_layer_grid, x_of_shore[:, row].squeeze())(
+        time_at_layer[:, 0]
+    )
+    x_of_shelf_edge = interp1d(time_at_layer_grid, x_of_shelf_edge[:, row].squeeze())(
         time_at_layer[:, 0]
     )
 

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -219,6 +219,8 @@ def plot_file(
     ----------
     filename : path-like
         Path to the file to plot.
+    row : int, optional
+        Row to plot. If not provided, plot the middle row.
 
     See Also
     --------

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -178,6 +178,8 @@ def plot_grid(grid: SequenceModelGrid, row: Optional[int] = None, **kwds: Any) -
     ----------
     grid : SequenceModelGrid
         The grid to plot.
+    row : int, optional
+        The row of the grid to plot. If not provided, plot the middle row.
 
     See Also
     --------
@@ -200,7 +202,9 @@ def plot_grid(grid: SequenceModelGrid, row: Optional[int] = None, **kwds: Any) -
     time_at_layer = grid.at_layer["age"]
 
     x_of_shore = interp1d(time_at_layer_grid, x_of_shore[:, row])(time_at_layer[:, 0])
-    x_of_shelf_edge = interp1d(time_at_layer_grid, x_of_shelf_edge[:, row])(time_at_layer[:, 0])
+    x_of_shelf_edge = interp1d(time_at_layer_grid, x_of_shelf_edge[:, row])(
+        time_at_layer[:, 0]
+    )
 
     kwds.setdefault("title", f"time = {time_at_layer[-1, 0]} years")
 

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -246,8 +246,8 @@ def plot_file(
 
         try:
             thickness_at_layer = ds["at_layer:thickness"][:, row, :]
-            x_of_shore = ds["at_row:x_of_shore"].data.squeeze()
-            x_of_shelf_edge = ds["at_row:x_of_shelf_edge"].data.squeeze()
+            x_of_shore = ds["at_row:x_of_shore"].data
+            x_of_shelf_edge = ds["at_row:x_of_shelf_edge"].data
             bedrock = (
                 ds["at_node:bedrock_surface__elevation"]
                 .data.reshape((-1, ds.dims["row"] + 2, ds.dims["column"] + 2))

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -171,7 +171,7 @@ def plot_layers(
     plt.show()
 
 
-def plot_grid(grid: SequenceModelGrid, **kwds: Any) -> None:
+def plot_grid(grid: SequenceModelGrid, row: Optional[int] = None, **kwds: Any) -> None:
     """Plot a :class:`~SequenceModelGrid`.
 
     Parameters
@@ -184,20 +184,23 @@ def plot_grid(grid: SequenceModelGrid, **kwds: Any) -> None:
     :func:`plot_layers` : Plot layers from a 2D array of elevations.
     :func:`plot_file` : Plot a `SequenceModelGrid`'s layers from a file.
     """
+    if row is None:
+        row = grid.number_of_rows // 2
+
     elevation_at_layer = (
-        grid.get_profile("bedrock_surface__elevation") + grid.at_layer.z
+        grid.get_profile("bedrock_surface__elevation")[row, 1:-1] + grid.at_layer.z
     )
 
-    x_of_stack = grid.x_of_column
+    x_of_stack = grid.x_of_column[1:-1]
 
-    x_of_shore = grid.at_layer_grid["x_of_shore"].flatten()
-    x_of_shelf_edge = grid.at_layer_grid["x_of_shelf_edge"].flatten()
+    x_of_shore = grid.at_layer_row["x_of_shore"]
+    x_of_shelf_edge = grid.at_layer_row["x_of_shelf_edge"]
 
     time_at_layer_grid = grid.at_layer_grid["age"].flatten()
     time_at_layer = grid.at_layer["age"]
 
-    x_of_shore = interp1d(time_at_layer_grid, x_of_shore)(time_at_layer[:, 0])
-    x_of_shelf_edge = interp1d(time_at_layer_grid, x_of_shelf_edge)(time_at_layer[:, 0])
+    x_of_shore = interp1d(time_at_layer_grid, x_of_shore[:, row])(time_at_layer[:, 0])
+    x_of_shelf_edge = interp1d(time_at_layer_grid, x_of_shelf_edge[:, row])(time_at_layer[:, 0])
 
     kwds.setdefault("title", f"time = {time_at_layer[-1, 0]} years")
 

--- a/sequence/sediment_flexure.py
+++ b/sequence/sediment_flexure.py
@@ -30,9 +30,11 @@ class DynamicFlexure(Flexure1D):
         else:
             self._isostasy_time = self.validate_isostasy_time(isostasytime)
 
-        super().__init__(grid, rows=1, method="flexure", **kwds)
+        active_rows = np.arange(1, grid.shape[0] - 1)
 
-        self._subsidence_pool = np.zeros(grid.shape[1], dtype=float)
+        super().__init__(grid, rows=active_rows, method="flexure", **kwds)
+
+        self._subsidence_pool = np.zeros((len(active_rows), grid.shape[1]), dtype=float)
 
     @staticmethod
     def validate_isostasy_time(time: float) -> float:
@@ -102,6 +104,8 @@ class DynamicFlexure(Flexure1D):
             The deflections over the given time step.
         """
         isostasy_fraction = self.calc_isostasy_fraction(self.isostasy_time, dt)
+
+        isostasy_fraction /= self.grid.shape[0] - 2
 
         self._subsidence_pool[:] += isostatic_deflection
         deflection = self._subsidence_pool[:] * isostasy_fraction

--- a/sequence/sequence.py
+++ b/sequence/sequence.py
@@ -78,6 +78,7 @@ class Sequence(Component):
         self._n_archived_layers = 0
 
         self.grid.at_layer_grid = EventLayers(1)
+        self.grid.at_layer_row = EventLayers(grid.number_of_rows)
 
         if "bedrock_surface__elevation" not in self.grid.at_node:
             self.grid.add_field(
@@ -225,6 +226,14 @@ class Sequence(Component):
             x_of_shelf_edge = self.grid.at_grid["x_of_shelf_edge"]
         except KeyError:
             x_of_shelf_edge = np.nan
+        try:
+            x_of_shores = self.grid.at_row["x_of_shore"]
+        except KeyError:
+            x_of_shores = np.full(self.grid.number_of_rows, np.nan)
+        try:
+            x_of_shelf_edges = self.grid.at_row["x_of_shelf_edge"]
+        except KeyError:
+            x_of_shelf_edges = np.full(self.grid.number_of_rows, np.nan)
 
         self.grid.at_node["topographic__elevation"][
             self.grid.node_at_cell
@@ -237,6 +246,13 @@ class Sequence(Component):
             sea_level=self.grid.at_grid["sea_level__elevation"],
             x_of_shore=x_of_shore,
             x_of_shelf_edge=x_of_shelf_edge,
+        )
+        self.grid.at_layer_row.add(
+            1.0,
+            age=self.time,
+            sea_level=self.grid.at_grid["sea_level__elevation"],
+            x_of_shore=x_of_shores,
+            x_of_shelf_edge=x_of_shelf_edges,
         )
 
         if (

--- a/sequence/sequence_model.py
+++ b/sequence/sequence_model.py
@@ -39,13 +39,12 @@ class SequenceModel:
         "flexure",
     )
     DEFAULT_PARAMS = {
-        "grid": {"n_cols": 100, "spacing": 1000.0},
+        "grid": {"shape": (1, 100), "spacing": (1.0, 1000.0)},
         "clock": {"start": 0.0, "stop": 600000.0, "step": 100.0},
         "output": {
             "interval": 10,
             "filepath": "sequence.nc",
             "clobber": True,
-            "rows": [1],
             "fields": ["sediment_deposit__thickness", "bedrock_surface__elevation"],
         },
         "submarine_diffusion": {

--- a/sequence/sequence_model.py
+++ b/sequence/sequence_model.py
@@ -116,8 +116,8 @@ class SequenceModel:
         if output is not None:
             self._components["output"] = OutputWriter(self._grid, **output)
 
-        self.grid.at_grid["x_of_shore"] = np.nan
-        self.grid.at_grid["x_of_shelf_edge"] = np.nan
+        self.grid.at_row["x_of_shore"][:] = np.nan
+        self.grid.at_row["x_of_shelf_edge"][:] = np.nan
         self.grid.at_grid["sea_level__elevation"] = 0.0
         self._n_archived_layers = 0
 

--- a/sequence/shoreline.py
+++ b/sequence/shoreline.py
@@ -290,7 +290,7 @@ def find_shoreline(
         try:
             index_at_shore = find_shoreline_index(x, z[row], sea_level=sea_level)
         except ShorelineError:
-            if z[0] < sea_level:
+            if z[row, 0] < sea_level:
                 x_of_shoreline = x[0]
             else:
                 x_of_shoreline = x[-1]

--- a/sequence/submarine.py
+++ b/sequence/submarine.py
@@ -168,10 +168,6 @@ class SubmarineDiffuser(LinearDiffuser):
         self._ksh = self._load / self._plain_slope
         self.grid.at_grid["sediment_load"] = self._load
 
-    # @property
-    # def k0(self):
-    #     return self._k0
-
     @property
     def load0(self) -> float:
         """Return the sediment load entering the profile."""
@@ -196,7 +192,9 @@ class SubmarineDiffuser(LinearDiffuser):
     def sea_level(self, sea_level: float) -> None:
         self.grid.at_grid["sea_level__elevation"] = sea_level
 
-    def calc_diffusion_coef(self, x_of_shore: float) -> NDArray[np.floating]:
+    def calc_diffusion_coef(
+        self, x_of_shore: NDArray[np.floating] | float
+    ) -> NDArray[np.floating]:
         """Calculate and store diffusion coefficient values.
 
         Parameters
@@ -232,34 +230,70 @@ class SubmarineDiffuser(LinearDiffuser):
         >>> diffusion_coef is grid.at_node["kd"]
         True
         """
+        x_of_shore = np.atleast_1d(x_of_shore)
+
         sea_level = self.grid.at_grid["sea_level__elevation"]
-        water_depth = sea_level - self._grid.at_node["topographic__elevation"]
 
-        under_water = water_depth > 0.0
-        deep_water = water_depth > self._wave_base
-        land = ~under_water
+        water_depth = sea_level - self._grid.get_profile("topographic__elevation")
+        k = self.grid.get_profile("kd")
+        x = self.grid.x_of_column
 
-        k = self.grid.at_node["kd"]
+        n_rows = k.shape[0]
 
-        x = self.grid.x_of_node
-        b = (self._shoreface_height * self._alpha + self._shelf_slope) * self.grid.dx
+        assert len(x_of_shore) == n_rows
 
-        k[under_water] = (
-            self._load
-            * ((x[under_water] - x_of_shore) + self.grid.dx)
-            / (water_depth[under_water] + b)
-        )
+        for row in range(n_rows):
+            under_water = water_depth[row] > 0.0
+            deep_water = water_depth[row] > self._wave_base
+            land = ~under_water
 
-        k[deep_water] *= np.exp(
-            -(water_depth[deep_water] - self._wave_base) / self._wave_base
-        )
+            b = (
+                self._shoreface_height * self._alpha + self._shelf_slope
+            ) * self.grid.dx
 
-        self._load = self._load0 * (1 + sea_level * self._load_sl)
-        self._ksh = self._load / self._plain_slope
-        if self._basin_width > 0.0:
-            k[land] = self._ksh * (self._basin_width + x[land]) / self._basin_width
-        else:
-            k[land] = self._ksh
+            k[row, under_water] = (
+                self._load
+                * ((x[under_water] - x_of_shore[row]) + self.grid.dx)
+                / (water_depth[row, under_water] + b)
+            )
+
+            k[row, deep_water] *= np.exp(
+                -(water_depth[row, deep_water] - self._wave_base) / self._wave_base
+            )
+
+            self._load = self._load0 * (1 + sea_level * self._load_sl)
+            self._ksh = self._load / self._plain_slope
+
+            if self._basin_width > 0.0:
+                k[row, land] = (
+                    self._ksh * (self._basin_width + x[land]) / self._basin_width
+                )
+            else:
+                k[row, land] = self._ksh
+
+            # TODO: modify diffusion outside of the channel row.
+            if row != n_rows // 2:
+                k[row, land] *= 0.5
+
+            # if row == n_rows // 2:
+            #     if self._basin_width > 0.0:
+            #         k[row, land] = self._ksh * (self._basin_width + x[land]) / self._basin_width
+            #     else:
+            #         k[row, land] = self._ksh
+            # else:  # outside of the channel with low diffusivity
+            #     if self._basin_width > 0.0:
+            #         k[row, land] = self._ksh * (self.grid.dx + x[land]) / self._basin_width
+            #     else:
+            #         k[row, land] = self._ksh * (self.grid.dx) / self._basin_width
+
+            # if self._basin_width > 0.0:
+            #     k[land] = self._ksh * (self._basin_width + x[land]) / self._basin_width
+            # else:
+            #     k[land] = self._ksh
+
+        k = self.grid.at_node["kd"].reshape(self.grid.shape)
+        k[0, :] = k[1, :]
+        k[-1, :] = k[-1, :]
 
         return k
 
@@ -272,20 +306,22 @@ class SubmarineDiffuser(LinearDiffuser):
             Time step to advance component by.
         """
         shore = find_shoreline(
-            self.grid.x_of_node[self.grid.node_at_cell],
-            self.grid.at_node["topographic__elevation"][self.grid.node_at_cell],
+            self.grid.x_of_column,
+            self.grid.get_profile("topographic__elevation"),
             sea_level=self.grid.at_grid["sea_level__elevation"],
         )
 
         self.calc_diffusion_coef(shore)
 
         # set elevation at upstream boundary to ensure proper sediment influx
-        x = self.grid.x_of_node.reshape(self.grid.shape)
+        x = self.grid.x_of_column
         z = self._grid.at_node["topographic__elevation"].reshape(self.grid.shape)
         # k = self._grid.at_node["kd"].reshape(self.grid.shape)
         # z[1, 0] = z[1,1] + self._load / k[1, 0] * (x[1,1]-x[1,0])
-        z[1, 0] = z[1, 1] + self._plain_slope * (x[1, 1] - x[1, 0])
-        # self._load/self._load0)
+        # z[1, 0] = z[1, 1] + self._plain_slope * (x[1, 1] - x[1, 0])
+        z[1, 0] = z[1, 1] + self._plain_slope * (x[1] - x[0])
+
+        z[1:-1, 0] = z[1:-1, 1] + self._plain_slope * (x[1] - x[0])
 
         z_before = self.grid.at_node["topographic__elevation"].copy()
 

--- a/sequence/submarine.py
+++ b/sequence/submarine.py
@@ -208,10 +208,10 @@ class SubmarineDiffuser(LinearDiffuser):
         sea level and three below, two of which are in deep water (below the
         default 60 m wave base).
 
-        >>> from landlab import RasterModelGrid
+        >>> from sequence import SequenceModelGrid
         >>> import numpy as np
 
-        >>> grid = RasterModelGrid((3, 6), xy_spacing=200.0)
+        >>> grid = SequenceModelGrid((1, 6), spacing=(1.0, 200.0))
         >>> z = grid.add_zeros("topographic__elevation", at="node")
         >>> z[6:12] = np.array([3., 3., 1., -1., -85., -85.])
         >>> z.reshape((3, 6))
@@ -297,7 +297,7 @@ class SubmarineDiffuser(LinearDiffuser):
         k[0, :] = k[1, :]
         k[-1, :] = k[-1, :]
 
-        return k
+        return self.grid.at_node["kd"]
 
     def run_one_step(self, dt: float) -> None:
         """Advance component one time step.

--- a/sequence/submarine.py
+++ b/sequence/submarine.py
@@ -277,7 +277,9 @@ class SubmarineDiffuser(LinearDiffuser):
 
             # if row == n_rows // 2:
             #     if self._basin_width > 0.0:
-            #         k[row, land] = self._ksh * (self._basin_width + x[land]) / self._basin_width
+            #         k[row, land] = (
+            #             self._ksh * (self._basin_width + x[land]) / self._basin_width
+            #         )
             #     else:
             #         k[row, land] = self._ksh
             # else:  # outside of the channel with low diffusivity

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -22,13 +22,11 @@ def test_from_dict():
 def test_from_dict_old_style():
     expected = SequenceModelGrid(500, spacing=5.0)
 
-    actual = SequenceModelGrid.from_dict(
-        {"shape": (13, 500), "xy_spacing": (5.0, 25.0)}
-    )
+    actual = SequenceModelGrid.from_dict({"shape": (1, 500), "xy_spacing": (5.0, 1.0)})
     assert actual.shape == expected.shape
     assert actual.spacing == expected.spacing
 
-    actual = SequenceModelGrid.from_dict({"shape": (13, 500), "xy_spacing": 5.0})
+    actual = SequenceModelGrid.from_dict({"shape": 500, "xy_spacing": 5.0})
     assert actual.shape == expected.shape
     assert actual.spacing == expected.spacing
 

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -94,7 +94,7 @@ def test_with_layers(tmpdir):
     grid = SequenceModelGrid(4)
     grid.event_layers.add(10.0, age=0.0, water_depth=np.arange(2))
     with tmpdir.as_cwd():
-        to_netcdf(grid, "test.nc")
+        to_netcdf(grid, "test.nc", ids={"row": [1], "column": [1, 2]})
         ds = xr.open_dataset("test.nc")
     assert ds.dims["layer"] == 1
     assert np.all(ds["at_layer:thickness"] == np.array([[10.0, 10.0]]))

--- a/tests/test_output_writer.py
+++ b/tests/test_output_writer.py
@@ -1,13 +1,13 @@
 import numpy as np
 import xarray as xr
-from landlab import RasterModelGrid
 from pytest import approx, raises
 
+from sequence import SequenceModelGrid
 from sequence.output_writer import OutputWriter
 
 
 def test_no_fields(tmpdir):
-    grid = RasterModelGrid((3, 4))
+    grid = SequenceModelGrid((1, 4), spacing=(1.0, 1.0))
     with tmpdir.as_cwd():
         writer = OutputWriter(grid, "test.nc")
         writer.run_one_step()
@@ -19,7 +19,7 @@ def test_no_fields(tmpdir):
 
 
 def test_default_output_interval(tmpdir):
-    grid = RasterModelGrid((3, 4))
+    grid = SequenceModelGrid((1, 4), spacing=(1.0, 1.0))
     with tmpdir.as_cwd():
         writer = OutputWriter(grid, "test.nc")
         for _ in range(4):
@@ -32,7 +32,7 @@ def test_default_output_interval(tmpdir):
 
 
 def test_output_interval(tmpdir):
-    grid = RasterModelGrid((3, 4))
+    grid = SequenceModelGrid((1, 4), spacing=(1.0, 1.0))
     with tmpdir.as_cwd():
         writer = OutputWriter(grid, "test.nc", interval=2)
         for _ in range(3):
@@ -45,7 +45,7 @@ def test_output_interval(tmpdir):
 
 
 def test_default_clobber_is_false(tmpdir):
-    grid = RasterModelGrid((3, 4))
+    grid = SequenceModelGrid((1, 4), spacing=(1.0, 1.0))
     with tmpdir.as_cwd():
         OutputWriter(grid, "test.nc").run_one_step()
         with raises(RuntimeError):
@@ -53,7 +53,7 @@ def test_default_clobber_is_false(tmpdir):
 
 
 def test_clobber_keyword(tmpdir):
-    grid = RasterModelGrid((3, 4))
+    grid = SequenceModelGrid((1, 4), spacing=(1.0, 1.0))
     with tmpdir.as_cwd():
         writer = OutputWriter(grid, "test.nc")
         for _ in range(10):
@@ -70,7 +70,7 @@ def test_clobber_keyword(tmpdir):
 
 
 def test_default_is_all_rows(tmpdir):
-    grid = RasterModelGrid((3, 4))
+    grid = SequenceModelGrid((1, 4), spacing=(1.0, 1.0))
     with tmpdir.as_cwd():
         OutputWriter(grid, "test.nc").run_one_step()
         with xr.open_dataset("test.nc") as ds:
@@ -78,14 +78,15 @@ def test_default_is_all_rows(tmpdir):
 
 
 def test_rows_keyword(tmpdir):
-    grid = RasterModelGrid((3, 4))
+    grid = SequenceModelGrid((1, 4), spacing=(1.0, 1.0))
     with tmpdir.as_cwd():
         OutputWriter(grid, "test.nc", rows=(1,)).run_one_step()
         with xr.open_dataset("test.nc") as ds:
-            assert np.all(ds.x_of_node == approx([0, 1, 2, 3]))
-            assert np.all(ds.y_of_node == approx(1.0))
+            assert np.all(ds.x_of_column == approx([0, 1]))
+            assert np.all(ds.y_of_row == approx(0.0))
 
-        OutputWriter(grid, "test.nc", rows=((0, 2),), clobber=True).run_one_step()
+        # OutputWriter(grid, "test.nc", rows=((0, 2),), clobber=True).run_one_step()
+        OutputWriter(grid, "test.nc", rows=(0, 2), clobber=True).run_one_step()
         with xr.open_dataset("test.nc") as ds:
-            assert np.all(ds.x_of_node == approx([0, 1, 2, 3, 0, 1, 2, 3]))
-            assert np.all(ds.y_of_node == approx([0, 0, 0, 0, 2, 2, 2, 2]))
+            assert np.all(ds.x_of_column == approx([0, 1]))
+            assert np.all(ds.y_of_row == approx([2, 1]))

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -70,15 +70,15 @@ def test_sequence_x_of_shore_missing(grid):
 def test_sequence_x_of_shore(grid):
     seq = Sequence(grid, components=[ShorelineFinder(grid)])
 
-    assert "x_of_shore" in grid.at_grid
-    assert "x_of_shelf_edge" in grid.at_grid
+    assert "x_of_shore" in grid.at_row
+    assert "x_of_shelf_edge" in grid.at_row
 
     assert grid.at_layer_grid.number_of_layers == 1
-    assert grid.at_layer_grid["x_of_shore"][-1] == pytest.approx(20000.0)
-    assert grid.at_layer_grid["x_of_shelf_edge"][-1] > 20000.0
+    assert np.all(grid.at_layer_row["x_of_shore"][-1, :] == pytest.approx(20000.0))
+    assert np.all(grid.at_layer_row["x_of_shelf_edge"][-1, :] > 20000.0)
 
     seq.update()
 
     assert grid.at_layer_grid.number_of_layers == 2
-    assert grid.at_layer_grid["x_of_shore"][-1] == pytest.approx(20000.0)
-    assert grid.at_layer_grid["x_of_shelf_edge"][-1] > 20000.0
+    assert np.all(grid.at_layer_row["x_of_shore"][-1, :] == pytest.approx(20000.0))
+    assert np.all(grid.at_layer_row["x_of_shelf_edge"][-1, :] > 20000.0)

--- a/tests/test_sequence_model/marmara.yaml
+++ b/tests/test_sequence_model/marmara.yaml
@@ -15,8 +15,7 @@ output:
   interval: 10
   filepath: marmara.nc
   clobber: True
-  rows:
-  - 1
+  rows: [0, 1, 2]
   fields:
   - sediment_deposit__thickness
   - kd

--- a/tests/test_subsidence.py
+++ b/tests/test_subsidence.py
@@ -73,7 +73,7 @@ def test_linear_subsidence(tmpdir):
         subsidence.run_one_step(dt=1.0)
         assert_array_equal(
             grid.get_profile("bedrock_surface__increment_of_elevation"),
-            [0.0, 10.0, 20.0, 30.0, 40.0],
+            [[0.0, 10.0, 20.0, 30.0, 40.0]],
         )
 
 
@@ -91,7 +91,7 @@ def test_add_to_existing_subsidence(tmpdir):
         subsidence.run_one_step(dt=1.0)
         assert_array_equal(
             grid.get_profile("bedrock_surface__increment_of_elevation"),
-            [1.0, 11.0, 21.0, 31.0, 41.0],
+            [[1.0, 11.0, 21.0, 31.0, 41.0]],
         )
 
 


### PR DESCRIPTION
This pull request adds the ability to run *Sequence* in a quasi-2d mode where sediment can move laterally in the cross-shore direction over multiple rows. Once deposited, sediment can then be transported in both the cross-shore and along-shore (i.e. between grid rows) directions.