### PR TITLE
Fix the failing CI workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,17 +19,23 @@ jobs:
             shell: bash -l {0}
 
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
 
-          - uses: mamba-org/setup-micromamba@v1
+          - uses: conda-incubator/setup-miniconda@v3
             with:
-              micromamba-version: latest
-              environment-name: testing
-              create-args: >-
-                python=3.11
-                mamba
-                pandoc
-                nox
+              python-version: 3.12
+              miniforge-variant: Miniforge3
+              miniforge-version: latest
+              auto-update-conda: true
+
+          - name: install and check pandoc
+            run: |
+              conda install pandoc -c conda-forge
+              pandoc --help
+              pandoc --version
+
+          - name: Install dependencies
+            run: pip install nox
 
           - name: Build documentation
             run: nox -s build-docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.12
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -24,7 +24,7 @@ jobs:
             with:
               auto-update-conda: true
               python-version: "3.11"
-              channels: conda-forge
+              channels: conda-forge,default
               channel-priority: true
 
           - name: Show conda installation info

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -19,8 +19,8 @@ jobs:
             shell: bash -l {0}
 
         steps:
-          - uses: actions/checkout@v2
-          - uses: conda-incubator/setup-miniconda@v2
+          - uses: actions/checkout@v4
+          - uses: conda-incubator/setup-miniconda@v3
             with:
               auto-update-conda: true
               python-version: "3.11"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniforge-variant: Miniforge3
           miniforge-version: latest
-          channels: conda-forge
+          channels: conda-forge,defaults
           channel-priority: true
 
       - name: Show conda installation info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,14 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
           channels: conda-forge
           channel-priority: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,8 +91,9 @@ repos:
   rev: v1.7.1
   hooks:
   - id: mypy
-    additional_dependencies: [types-all]
+    language_version: python3.12
     files: sequence/.*\.py$
+    additional_dependencies: ["types-pyyaml"]
 
 - repo: https://github.com/citation-file-format/cff-converter-python
   rev: 44e8fc9174119805b64b0b333aa69d285a866673

--- a/docs/how_to_guides/install/developer_install.md
+++ b/docs/how_to_guides/install/developer_install.md
@@ -5,7 +5,7 @@
 :::{important}
 The following commands will install *sequence* into your current environment. Although
 not necessary, we **highly recommend** you install sequence into its own
-{ref}`virtual environment <virtual_environments>`.
+{ref}`virtual environment <virtual-environments>`.
 :::
 
 If you will be modifying code or contributing new code to *sequence*, you will first

--- a/docs/how_to_guides/install/index.md
+++ b/docs/how_to_guides/install/index.md
@@ -9,7 +9,7 @@
 :::{important}
 The following commands will install *sequence* into your current environment. Although
 not necessary, we **highly recommend** you install sequence into its own
-{ref}`virtual environment <virtual_environments>`.
+{ref}`virtual environment <virtual-environments>`.
 :::
 
 <!-- start-install-release -->

--- a/docs/how_to_guides/install/installation.md
+++ b/docs/how_to_guides/install/installation.md
@@ -5,7 +5,7 @@
 :::{important}
 The following commands will install *sequence* into your current environment. Although
 not necessary, we **highly recommend** you install sequence into its own
-{ref}`virtual environment <virtual_environments>`.
+{ref}`virtual environment <virtual-environments>`.
 :::
 
 <!-- start-install-release -->

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -8,3 +8,4 @@ sphinx-click
 sphinx-inline-tabs
 sphinx_copybutton
 sphinxcontrib.towncrier
+towncrier<24

--- a/news/86.misc
+++ b/news/86.misc
@@ -1,0 +1,3 @@
+
+Fixed some failing CI workflows due to old versions of GitHub Actions
+and *numpy* 2.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "compaction",
     "landlab",
     "netcdf4",
-    "numpy >=1.22",
+    "numpy >=1.22, <2",
     "pyyaml",
     "rich-click",
     "scipy",

--- a/sequence/grid.py
+++ b/sequence/grid.py
@@ -37,7 +37,7 @@ class SequenceModelGrid(RasterModelGrid):
         >>> from sequence.grid import SequenceModelGrid
         >>> grid = SequenceModelGrid(5, spacing=10.0)
         >>> grid.y_of_row
-        array([  0.,  1.,  2.])
+        array([0.,  1.,  2.])
         >>> grid.x_of_column
         array([ 0.,  10.,  20.,  30.,  40.])
 
@@ -155,14 +155,14 @@ class SequenceModelGrid(RasterModelGrid):
         >>> params = {"shape": 5, "spacing": 10.0}
         >>> grid = SequenceModelGrid.from_dict(params)
         >>> grid.y_of_row
-        array([  0.,  1.,  2.])
+        array([0.,  1.,  2.])
         >>> grid.x_of_column
         array([ 0.,  10.,  20.,  30.,  40.])
 
         >>> params = {"shape": (3, 5), "spacing": (10000.0, 10.0)}
         >>> grid = SequenceModelGrid.from_dict(params)
         >>> grid.y_of_row
-        array([  0.,  10000.,  20000.,  30000., 40000.])
+        array([ 0.,  10000.,  20000.,  30000., 40000.])
         >>> grid.x_of_column
         array([ 0.,  10.,  20.,  30.,  40.])
         """

--- a/sequence/sediment_flexure.py
+++ b/sequence/sediment_flexure.py
@@ -537,7 +537,7 @@ class SedimentFlexure(DynamicFlexure):
         >>> SedimentFlexure._calc_density(0.5, 1600, 1200)
         1400.0
         >>> SedimentFlexure._calc_density([1.0, 0.75, 0.5, 0.25, 0.0], 1600.0, 1200.0)
-        array([ 1600.,  1500.,  1400.,  1300.,  1200.])
+        array([1600.,  1500.,  1400.,  1300.,  1200.])
         """
         sand_fraction = np.asarray(sand_fraction)
         return sand_fraction * sand_density + (1.0 - sand_fraction) * mud_density

--- a/sequence/shoreline.py
+++ b/sequence/shoreline.py
@@ -298,7 +298,12 @@ def find_shoreline(
                 x_of_shoreline = x[-1]
         else:
             func = interpolate.interp1d(x, z[row] - sea_level, kind=kind)
-            x_of_shoreline = bisect(func, x[index_at_shore - 1], x[index_at_shore])
+            if np.isclose(func(x[index_at_shore - 1]), 0.0):
+                x_of_shoreline = x[index_at_shore - 1]
+            elif np.isclose(func(x[index_at_shore]), 0.0):
+                x_of_shoreline = x[index_at_shore]
+            else:
+                x_of_shoreline = bisect(func, x[index_at_shore - 1], x[index_at_shore])
         x_of_shorelines[row] = x_of_shoreline
 
     if n_rows == 1:

--- a/sequence/submarine.py
+++ b/sequence/submarine.py
@@ -227,7 +227,7 @@ class SubmarineDiffuser(LinearDiffuser):
         >>> diffusion_coef = submarine_diffuser.calc_diffusion_coef(x_of_shore=500.0)
 
         >>> np.round(diffusion_coef.reshape((3, 6))[1])
-        array([ 3750.,  3750.,  3750.,   333.,    11.,    16.])
+        array([3750.,  3750.,  3750.,   333.,    11.,    16.])
 
         The calculated diffusion coefficient is also saved as an *at-node* field.
 


### PR DESCRIPTION
I've fixed the failing workflows. This fixes were fairly minor,
* Bumped version of actions
* Require numpy<2 for now just so the doctests pass (I'll lift this restriction in another pr)
* Fixed a flaky test when checking the shoreline finder
* For the docs to build, limit *towncrier* to < 24 (newer versions are incompatible with *sphinxcontrib-towncrier*)