### PR TITLE
Add coverage nox session, run coverage as a separte gha job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,9 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
-    # We want to run on external PRs, but not on our own internal PRs as they'll be run
-    # by the push to the branch. Without this if check, checks are duplicated since
-    # internal PRs match both the push and pull_request events.
-    if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ${{ matrix.os }}
 
@@ -53,8 +50,10 @@ jobs:
           nox -s test-cli --force-pythons="${{ matrix.python-version }}" -- -m "${{ matrix.pytest-marker }}"
 
   coverage:
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     name: Run coverage
-    needs: build-and-test
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12"]
+        exclude:
+          # This is tested in the coverage job
+          - os: ubuntu-latest
+            python-version: "3.12"
 
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +52,36 @@ jobs:
         run: |
           nox -s test-cli --force-pythons="${{ matrix.python-version }}" -- -m "${{ matrix.pytest-marker }}"
 
+  coverage:
+    name: Run coverage
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: 3.12
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
+          channels: conda-forge,defaults
+          channel-priority: true
+
+      - name: coverage
+        env:
+          COVERAGE_CORE": "sysmon"
+        run: |
+          pip install nox
+          nox --verbose -s coverage --force-pythons=3.12
+
       - name: Coveralls
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        uses: AndreMiras/coveralls-python-action@v20201129
+        uses: AndreMiras/coveralls-python-action@develop
+        with:
+          parallel: true
+          flag-name: py3.12-ubuntu-latest
+          debug: true

--- a/news/89.misc
+++ b/news/89.misc
@@ -1,0 +1,3 @@
+
+Added a new *nox* session, *coverage*, to run coverage. The *test* session now
+just runs the tests without coverage.

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ def test(session: nox.Session) -> None:
 @nox.session(python=PYTHON_VERSION, venv_backend="conda")
 def coverage(session: nox.Session) -> None:
     session.install("coverage", "pytest", "pytest-datadir", "pytest-runner")
-    session.install(".")
+    session.install("-e", ".")
 
     session.run("coverage", "erase")
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,10 +27,29 @@ def test(session: nox.Session) -> None:
     session.install("-r", "requirements-testing.in")
     session.install(".")
 
-    args = session.posargs or ["-n", "auto", "--cov", PROJECT, "-vvv"]
+    session.run("pytest", "-n", "auto", "-vvv")
+
+
+@nox.session(python=PYTHON_VERSION, venv_backend="conda")
+def coverage(session: nox.Session) -> None:
+    session.install("coverage", "pytest", "pytest-datadir", "pytest-runner")
+    session.install(".")
+
+    session.run("coverage", "erase")
+    session.run(
+        "coverage",
+        "run",
+        "--source=sequence",
+        "--module",
+        "pytest",
+        "-vvv",
+        env={"COVERAGE_CORE": "sysmon"},
+    )
+
     if "CI" in os.environ:
-        args.append("--cov-report=xml:$(pwd)/coverage.xml")
-    session.run("pytest", *args)
+        session.run("coverage", "xml", "-o", os.path.join(ROOT, "coverage.xml"))
+    else:
+        session.run("coverage", "report", "--ignore-errors", "--show-missing")
 
 
 @nox.session(name="test-notebooks", python=PYTHON_VERSION, venv_backend="conda")

--- a/requirements-testing.in
+++ b/requirements-testing.in
@@ -1,6 +1,4 @@
-coverage
 pytest
-pytest-cov
 pytest-datadir
 pytest-runner
 pytest-xdist


### PR DESCRIPTION
There's really no need to run coverage for all supported python versions and operating systems. I've added a new *nox* session, `coverage`, which runs coverage, and removed coverage from the *test* session.  This has the added benefit that it should speed the tests up just a little. I set `COVERAGE_CORE"=sysmon` when running coverage but I think that might only make a difference in Python 3.13, which we're not testing yet.