### PR TITLE
Remove conda environments from the tests

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -20,12 +20,10 @@ jobs:
 
         steps:
           - uses: actions/checkout@v4
-          - uses: conda-incubator/setup-miniconda@v3
+          - name: Use Python 3.12
+            uses: actions/setup-python@v5
             with:
-              auto-update-conda: true
-              python-version: "3.11"
-              channels: conda-forge,default
-              channel-priority: true
+              python-version: "3.12"
 
           - name: Show conda installation info
             run: conda info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,28 +26,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Use Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Miniforge3
-          miniforge-version: latest
-          channels: conda-forge,defaults
-          channel-priority: true
-
-      - name: Show conda installation info
-        run: conda info
 
       - name: Install dependencies
         run: pip install nox
 
       - name: Test
         run: |
-          nox -s test --force-pythons="${{ matrix.python-version }}" -- -m "${{ matrix.pytest-marker }}"
+          nox -s test
 
       - name: Test the cli
         run: |
-          nox -s test-cli --force-pythons="${{ matrix.python-version }}" -- -m "${{ matrix.pytest-marker }}"
+          nox -s test-cli
 
   coverage:
     if: |
@@ -62,21 +55,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
-          auto-update-conda: true
-          python-version: 3.12
-          miniforge-variant: Miniforge3
-          miniforge-version: latest
-          channels: conda-forge,defaults
-          channel-priority: true
+          python-version: "3.12"
 
       - name: coverage
         env:
           COVERAGE_CORE": "sysmon"
         run: |
           pip install nox
-          nox --verbose -s coverage --force-pythons=3.12
+          nox --verbose -s coverage
 
       - name: Coveralls
         uses: AndreMiras/coveralls-python-action@develop

--- a/news/90.misc
+++ b/news/90.misc
@@ -1,0 +1,3 @@
+
+Remove *conda* environments from the *nox* file and from the CI
+testing workflows.

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,7 @@ FOLDER = {
 }
 
 
-@nox.session(python=PYTHON_VERSION, venv_backend="conda")
+@nox.session
 def test(session: nox.Session) -> None:
     """Run the tests."""
     session.install("-r", "requirements-testing.in")
@@ -30,7 +30,7 @@ def test(session: nox.Session) -> None:
     session.run("pytest", "-n", "auto", "-vvv")
 
 
-@nox.session(python=PYTHON_VERSION, venv_backend="conda")
+@nox.session
 def coverage(session: nox.Session) -> None:
     session.install("coverage", "pytest", "pytest-datadir", "pytest-runner")
     session.install("-e", ".")
@@ -52,7 +52,7 @@ def coverage(session: nox.Session) -> None:
         session.run("coverage", "report", "--ignore-errors", "--show-missing")
 
 
-@nox.session(name="test-notebooks", python=PYTHON_VERSION, venv_backend="conda")
+@nox.session(name="test-notebooks")
 def test_notebooks(session: nox.Session) -> None:
     """Run the notebooks."""
     session.install("nbmake")
@@ -63,7 +63,7 @@ def test_notebooks(session: nox.Session) -> None:
     session.run("pytest", "--nbmake", str(FOLDER["notebooks"]))
 
 
-@nox.session(name="test-cli", python=PYTHON_VERSION, venv_backend="conda")
+@nox.session(name="test-cli")
 def test_cli(session: nox.Session) -> None:
     """Test the command line interface."""
     session.install(".")


### PR DESCRIPTION
There's no need to setup *conda* environments for testing, so I've removed them. This should speed up the CI since the conda environments are slower to create.