### PR TITLE
Fix netcdf warnings from xarray

### DIFF
--- a/news/91.misc
+++ b/news/91.misc
@@ -1,0 +1,3 @@
+
+Removed deprecated usage of Dataset.dims to get the size of a dimension,
+use Dataset.sizes instead.

--- a/sequence/netcdf.py
+++ b/sequence/netcdf.py
@@ -345,7 +345,7 @@ def to_netcdf(
         grid,
         at="row",
         ids=ids_dict["row"],
-        names=["x_of_shore", "x_of_shelf_edge"],
+        names={"x_of_shore", "x_of_shelf_edge"} & set(grid["row"]),
     )
 
     if with_layers:

--- a/sequence/plot.py
+++ b/sequence/plot.py
@@ -248,9 +248,9 @@ def plot_file(filename: str | PathLike, row: int | None = None, **kwds: Any) -> 
             raise MissingRequiredVariable("row")
 
         if row is None:
-            row = ds.dims["row"] // 2
-        elif (row >= ds.dims["row"]) or (row < -ds.dims["row"]):
-            raise InvalidRowError(row, ds.dims["row"])
+            row = ds.sizes["row"] // 2
+        elif (row >= ds.sizes["row"]) or (row < -ds.sizes["row"]):
+            raise InvalidRowError(row, ds.sizes["row"])
 
         try:
             thickness_at_layer = ds["at_layer:thickness"][:, row, :]
@@ -258,12 +258,12 @@ def plot_file(filename: str | PathLike, row: int | None = None, **kwds: Any) -> 
             x_of_shelf_edge = ds["at_row:x_of_shelf_edge"].data
             bedrock = (
                 ds["at_node:bedrock_surface__elevation"]
-                .data.reshape((-1, ds.dims["row"] + 2, ds.dims["column"] + 2))
+                .data.reshape((-1, ds.sizes["row"] + 2, ds.sizes["column"] + 2))
                 .squeeze()
             )
             time = ds["time"]
             time_at_layer = ds["at_layer:age"].data.reshape(
-                (-1, ds.dims["row"], ds.dims["column"])
+                (-1, ds.sizes["row"], ds.sizes["column"])
             )
         except KeyError as err:
             raise MissingRequiredVariable(str(err)) from err
@@ -271,11 +271,11 @@ def plot_file(filename: str | PathLike, row: int | None = None, **kwds: Any) -> 
         try:
             x_of_stack = (
                 ds["x_of_cell"]
-                .data.reshape((ds.dims["row"], ds.dims["column"]))[row, :]
+                .data.reshape((ds.sizes["row"], ds.sizes["column"]))[row, :]
                 .squeeze()
             )
         except KeyError:
-            x_of_stack = np.arange(ds.dims["cell"])
+            x_of_stack = np.arange(ds.sizes["cell"])
 
         elevation_at_layer = bedrock[-1, row, 1:-1] + np.cumsum(
             thickness_at_layer, axis=0

--- a/tests/netcdf_test.py
+++ b/tests/netcdf_test.py
@@ -98,7 +98,7 @@ def test_with_layers(tmpdir):
     with tmpdir.as_cwd():
         to_netcdf(grid, "test.nc", ids={"row": [1], "column": [1, 2]})
         ds = xr.open_dataset("test.nc")
-    assert ds.dims["layer"] == 1
+    assert ds.sizes["layer"] == 1
     assert np.all(ds["at_layer:thickness"] == np.array([[10.0, 10.0]]))
     assert np.all(ds["at_layer:age"] == np.array([[0.0, 0.0]]))
     assert np.all(ds["at_layer:water_depth"] == np.array([[0.0, 1.0]]))


### PR DESCRIPTION
We were getting deprecation warning about using `Dataset.dims` to get the size of a dimension. The preferred way to do this is now `Dataset.sizes`.